### PR TITLE
Updates for Confluence Run - Spring 2026

### DIFF
--- a/src/geoglows_aws_pull.py
+++ b/src/geoglows_aws_pull.py
@@ -7,15 +7,17 @@ import datetime
 
 def pull_tributary(reach_id, start_date):
     start_date = datetime.datetime.strptime(start_date, "%m-%d-%Y").date()
-    end_date = datetime.date.today()
     sim_begin = datetime.date(1940, 1, 1)
     first_index = start_date - sim_begin
-    second_index = end_date - sim_begin
     bucket_uri = "s3://geoglows-v2/retrospective/daily.zarr"
     region_name = "us-west-2"
     s3 = s3fs.S3FileSystem(anon=True, client_kwargs=dict(region_name=region_name))
     s3store = s3fs.S3Map(root=bucket_uri, s3=s3, check=False)
     ds = xarray.open_zarr(s3store)
+    
+    end_date = min(datetime.date.today(), pd.Timestamp(ds["time"].values[-1]).date())
+    second_index = end_date - sim_begin
+    
     df = (
         ds["Q"]
         .sel(river_id=reach_id, time=slice(start_date, end_date))

--- a/src/lakeflow_1.R
+++ b/src/lakeflow_1.R
@@ -37,18 +37,18 @@ use_python("/usr/local/bin/python3.12")
 ################################################################################
 # Constants
 
-SWORD_VERSION = "16"
+SWORD_VERSION = "17"
 
 ################################################################################
 # Set args
 option_list <- list(
-    make_option(c("-c", "--input_file"), type = "character", default = NULL, help = "filepath to csv with lake ids to download data, point it to reaches_of_interest.json to process lakes associated with those reaches"),
-    make_option(c("-w", "--workers"), type = "integer", default = NULL, help = "number of workers to use to download swot data"),
-    make_option(c("-i", "--indir"), type = "character", default = NULL , help = "directory with input files"),
-    make_option(c("-p", "--prefix"), type = "character", default = "", help = "prefix for hydrocron api-key storage")
-    ## I had an index argument, but the script is actually faster in seriel instead of calling hydrocron in parallel
-    # make_option(c("--index"), type = "integer", default = NULL , help = "Chooses what lake to process from input file, if -256 it usese AWS array number")
-  )
+  make_option(c("-c", "--input_file"), type = "character", default = NULL, help = "filepath to csv with lake ids to download data, point it to reaches_of_interest.json to process lakes associated with those reaches"),
+  make_option(c("-w", "--workers"), type = "integer", default = NULL, help = "number of workers to use to download swot data"),
+  make_option(c("-i", "--indir"), type = "character", default = NULL , help = "directory with input files"),
+  make_option(c("-p", "--prefix"), type = "character", default = "", help = "prefix for hydrocron api-key storage"),
+  ## I had an index argument, but the script is actually faster in seriel instead of calling hydrocron in parallel
+  make_option(c("--index"), type = "integer", default = NULL , help = "Chooses what lake to process from input file, if -256 it uses array number")
+)
 ################################################################################
 
 # Grab arguments
@@ -65,25 +65,33 @@ indir <- opts$indir
 # Prefix for hydrocron API in the parameter store
 prefix <- opts$prefix
 
+# Set index, use array if index is -256
+index <- opts$index
+if (index == -256){
+  index <- strtoi(Sys.getenv("SLURM_ARRAY_TASK_ID"))
+}
+
+cat("SLURM_ARRAY_TASK_ID inside R:", Sys.getenv("SLURM_ARRAY_TASK_ID"), "\n")
+
 ################################################################################
 # Load datasets
 ################################################################################
 
 # Load PLD dataset
-updated_pld = fread(file.path(indir,"/SWORDv16_PLDv103_wo_ghost_rch.csv"))
+updated_pld = fread(file.path(indir,"/SWORDv17b_PLDv201.csv"))
 updated_pld$lake_id =  as.character(updated_pld$lake_id)
 updated_pld$continent = substr(updated_pld$lake_id, 1,1)
 
-# Load ET dataset
-et = fread(file.path(indir, '/ancillary/et.csv'))
-et$lake_id <- as.character(et$lake_id)
+# Load supplementary ET dataset
+et_supplement = fread(file.path(indir, '/ancillary/et_supplement.csv'))
+et_supplement$lake_id <- as.character(et_supplement$lake_id)
 
 # Load tributary dataset
-tributary = fread(file.path(indir,'/ancillary/tributaries.csv'))
+tributary = fread(file.path(indir,'/ancillary/tributaries_w_ghost_reach.csv'))
 tributary$lake_id <- as.character(tributary$lake_id)
 
 # Load geoglows dataset
-sword_geoglows = fread(file.path(indir,'/ancillary/sword_geoglows.csv'))
+sword_geoglows = fread(file.path(indir,'/ancillary/sword_geoglows_w_ghost_reach.csv'))
 sword_geoglows$reach_id = as.character(sword_geoglows$reach_id)
 
 # Create a folder to store the downloaded/processed datasets
@@ -104,38 +112,38 @@ get_connected_lake_ids <- function(reach_ids, pld) {
       any(ids %in% reach_ids)
     })
   }
-
+  
   # Find rows where either upstream or downstream reach_id lists contain any of the reach_ids
   is_connected_up <- has_overlap(pld$U_reach_id, reach_ids)
   is_connected_dn <- has_overlap(pld$D_reach_id, reach_ids)
-
+  
   # Combine the logical vectors and get lake_ids
   connected_lakes <- unique(pld$lake_id[is_connected_up | is_connected_dn])
-
+  
   return(connected_lakes)
 }
 
 get_api_key <- function(prefix) {
-    ssm <- paws::ssm()
-    
-    tryCatch({
-      param_name <- paste0(prefix, "-hydrocron-key")
-      response <- ssm$get_parameter(
-        Name = param_name,
-        WithDecryption = TRUE
-      )
-      api_key <- response$Parameter$Value
-      log_info("Querying with Hydrocron API key.")
-      return(api_key)
-    }, error = function(e) {
-      log_error(e$message)
-      log_info("Not querying with Hydrocron API key.")
-      return("")
-    })
-  }
+  ssm <- paws::ssm()
+  
+  tryCatch({
+    param_name <- paste0(prefix, "-hydrocron-key")
+    response <- ssm$get_parameter(
+      Name = param_name,
+      WithDecryption = TRUE
+    )
+    api_key <- response$Parameter$Value
+    log_info("Querying with Hydrocron API key.")
+    return(api_key)
+  }, error = function(e) {
+    log_error(e$message)
+    log_info("Not querying with Hydrocron API key.")
+    return("")
+  })
+}
 
 pull_lake_data <- function(feature_id, api_key){
-  website = paste0('https://soto.podaac.earthdatacloud.nasa.gov/hydrocron/v1/timeseries?feature=PriorLake&feature_id=',feature_id, '&start_time=2023-01-01T00:00:00Z&end_time=2025-12-31T00:00:00Z&output=csv&fields=lake_id,time_str,wse,area_total,xovr_cal_q,partial_f,dark_frac,ice_clim_f')
+  website = paste0('https://soto.podaac.earthdatacloud.nasa.gov/hydrocron/v1/timeseries?collection_name=SWOT_L2_HR_LakeSP_D&feature=PriorLake&feature_id=',feature_id, '&start_time=2023-01-01T00:00:00Z&end_time=2027-12-31T00:00:00Z&output=csv&fields=lake_id,time_str,wse,area_total,xovr_cal_q,partial_f,dark_frac,ice_clim_f,xtrk_dist,quality_f,partial_f')
   if (nzchar(api_key)) {
     # do something
     response = GET(website, add_headers("x-hydrocon-key" = api_key))
@@ -150,9 +158,9 @@ pull_lake_data <- function(feature_id, api_key){
   } else {
     return(NA)
   }
-
+  
   if(is.error(data)){return(NA)}
-
+  
   data$reach_id = feature_id
   return(data)
 }
@@ -169,7 +177,7 @@ batch_download_SWOT_lakes <- function(obs_ids, api_key){
 pull_data <- function(feature_id, api_key){
   # print("pulling data")
   # Function to pull swot reach data using hydrocron
-  website = paste0('https://soto.podaac.earthdatacloud.nasa.gov/hydrocron/v1/timeseries?feature=Reach&feature_id=',feature_id, '&start_time=2023-01-01T00:00:00Z&end_time=2025-12-31T00:00:00Z&output=csv&fields=reach_id,time_str,wse,width,slope,slope2,d_x_area,area_total,reach_q,p_width,xovr_cal_q,partial_f,dark_frac,ice_clim_f,wse_r_u,slope_r_u,reach_q_b')
+  website = paste0('https://soto.podaac.earthdatacloud.nasa.gov/hydrocron/v1/timeseries?collection_name=SWOT_L2_HR_RiverSP_D&feature=Reach&feature_id=',feature_id, '&start_time=2023-01-01T00:00:00Z&end_time=2027-12-31T00:00:00Z&output=csv&fields=reach_id,time_str,wse,width,slope,slope2,d_x_area,area_total,reach_q,p_width,xovr_cal_q,partial_f,dark_frac,ice_clim_f,wse_r_u,slope_r_u,reach_q_b,p_low_slp,p_length,xtrk_dist,obs_frac_n,p_n_nodes')
   if (nzchar(api_key)) {
     # do something
     response = GET(website, add_headers("x-hydrocon-key" = api_key))
@@ -185,7 +193,7 @@ pull_data <- function(feature_id, api_key){
   }
   
   if(is.error(data)){return(NA)}
-
+  
   data$reach_id = feature_id
   return(data)
 }
@@ -202,15 +210,15 @@ batch_download_SWOT <- function(obs_ids, api_key){
 tukey_test = function(ts){
   # print("running tukey")
   # Turkey test for removing outliers
-  wseIQR = quantile(ts$wse, c(.25, .75))
+  wseIQR = quantile(ts$wse, c(.25, .75), na.rm = TRUE)
   wseT_l = wseIQR[1] - (diff(wseIQR)*1.5)
   wseT_u = wseIQR[2] + (diff(wseIQR)*1.5)
   
-  slopeIQR = quantile(ts$slope2, c(.25, .75))
+  slopeIQR = quantile(ts$slope2, c(.25, .75), na.rm = TRUE)
   slopeT_l = slopeIQR[1] - (diff(slopeIQR)*1.5)
   slopeT_u = slopeIQR[2] + (diff(slopeIQR)*1.5)
   
-  widthIQR = quantile(ts$width, c(.25, .75))
+  widthIQR = quantile(ts$width, c(.25, .75), na.rm = TRUE)
   widthT_l = widthIQR[1] - (diff(widthIQR)*1.5)
   widthT_u = widthIQR[2] + (diff(widthIQR)*1.5)
   
@@ -221,7 +229,7 @@ tukey_test = function(ts){
 tukey_test_lake = function(ts){
   # print("running tukey lake")
   # Turkey test for removing outliers 
-  wseIQR = quantile(ts$wse, c(.25, .75))
+  wseIQR = quantile(ts$wse, c(.25, .75), na.rm = TRUE)
   wseT_l = wseIQR[1] - (diff(wseIQR)*1.5)
   wseT_u = wseIQR[2] + (diff(wseIQR)*1.5)
   
@@ -235,61 +243,99 @@ filter_function = function(swot_ts){
   # Allowing partial obs to see if it degrades performances. 
   #dawg_filter = tukey_test(swot_ts[swot_ts$time_str!='no_data'&swot_ts$ice_clim_f<2&swot_ts$dark_frac<=0.5&swot_ts$xovr_cal_q<2&!is.na(swot_ts$slope2)&!is.infinite(swot_ts$slope2)&swot_ts$slope2>0&swot_ts$width>0,])
   dawg_filter = tukey_test(swot_ts[swot_ts$time_str!='no_data'&swot_ts$ice_clim_f<2&swot_ts$dark_frac<=0.5&swot_ts$xovr_cal_q<2&swot_ts$partial_f==0&!is.na(swot_ts$slope2)&!is.infinite(swot_ts$slope2)&swot_ts$slope2>0&swot_ts$width>0,])
+  perm_relax_filter = tukey_test(swot_ts[swot_ts$time_str!='no_data' & #original lakeflow filters
+                                           swot_ts$partial_f == 0 &
+                                           !is.na(swot_ts$slope2) &
+                                           !is.infinite(swot_ts$slope2) &
+                                           swot_ts$slope2 > 0 &
+                                           swot_ts$width > 0 &
+                                           swot_ts$p_width >= 60 & #permanent relaxed filters
+                                           swot_ts$p_low_slp <= 0 & 
+                                           swot_ts$p_length >= 5000 & 
+                                           ((swot_ts$xtrk_dist >= 10000 & swot_ts$xtrk_dist <= 60000) | (swot_ts$xtrk_dist >= -60000 & swot_ts$xtrk_dist <= -10000)) & 
+                                           swot_ts$ice_clim_f <= 1 & 
+                                           swot_ts$reach_q <= 2 & 
+                                           swot_ts$dark_frac <= 0.6 & 
+                                           swot_ts$obs_frac_n > 0.4 & 
+                                           swot_ts$xovr_cal_q <= 1 & 
+                                           swot_ts$p_n_nodes >= 10,])
   qual_filter = swot_ts[swot_ts$time_str!='no_data'&swot_ts$reach_q<=2,]
   ssf_filter = tukey_test(swot_ts[swot_ts$time_str!='no_data'&swot_ts$reach_q_b<=32768&swot_ts$dark_frac<=0.1&swot_ts$wse_r_u<=0.5&swot_ts$slope_r_u<=10e-5&swot_ts$ice_clim_f==0&swot_ts$xovr_cal_q<=1,])
-  return(dawg_filter)
+  return(perm_relax_filter)
 }
 
 # Ryan's updated code to get data from farther up/downstream reaches
 combining_lk_rv_obs = function(lake, api_key){
   # print("combining lake and river obs")
-
+  
   #Pull in SWOT river data and subset predownloaded SWOT lake data. 
   upID = unlist(strsplit(updated_pld$U_reach_id[updated_pld$lake_id==lake], ','))
   dnID = unlist(strsplit(updated_pld$D_reach_id[updated_pld$lake_id==lake], ','))
   upObs_all = swot_river[swot_river$reach_id%in%upID,]
   dnObs_all = swot_river[swot_river$reach_id%in%dnID,]
   dnObs_all$reach_id <- as.character(dnObs_all$reach_id)
-
+  
   sword_continents = list("af", "eu", "as", "as", "oc", "sa", "na", "na", "na")
-
+  
   #Allow downstream reaches to shift one reach downstream.
   n_ds_reaches = updated_pld$D_reach_n[updated_pld$lake_id==lake]
   n_ds_reaches_obs = dnObs_all[,.N,by=reach_id]
   missing_dn = dnID[dnID%!in%n_ds_reaches_obs$reach_id]
   shift_a_reach_away = function(f, api_key){
     print("Shift a reach away...")
-
+    
     reach_id = as.character(f)
     reach_continent = strtoi(substring(reach_id, 1, 1))
     continent = paste0(sword_continents[reach_continent], "_sword_v", SWORD_VERSION, ".nc")
     
-    sword_nc = nc_open(file.path(dirname(indir), "sword", continent))
+    sword_nc = nc_open(file.path(indir, "sword", continent))
     sword = list(reach_id=ncvar_get(sword_nc, "reaches/reach_id"),
                  rch_id_dn=ncvar_get(sword_nc, "reaches/rch_id_dn"),
-                 n_rch_dn=ncvar_get(sword_nc, "reaches/n_rch_down")
+                 n_rch_dn=ncvar_get(sword_nc, "reaches/n_rch_down"),
+                 facc=ncvar_get(sword_nc, "reaches/facc"),
+                 swot_orbits=ncvar_get(sword_nc, "reaches/swot_orbits")
     )
     nc_close(sword_nc)
-
-    n_alt_ds_reaches = sword$n_rch_dn[sword$reach_id==f]
-
-    if(n_alt_ds_reaches==1){
-      alt_ds_reach = sword$rch_id_dn[sword$reach_id==f]
-      dn_river_pull = try(lapply(alt_ds_reach, pull_data, api_key = api_key))
-      dn_river_filt = lapply(dn_river_pull[!is.na(dn_river_pull)], filter_function)
-      dnObs_alt = rbindlist(dn_river_filt)
-      dnObs_alt$time=as_datetime(dnObs_alt$time_str)
-      dnObs_alt$reach_id_original = dnObs_alt$reach_id
-      dnObs_alt$reach_id = f
-      dnObs_alt$shifted = 'yes'
-      if(nrow(dnObs_alt)>0){
-        return(dnObs_alt)
+    
+    reach = f
+    
+    #How many reaches can we shift downstream?
+    max_shift_ds_reaches = 5
+    
+    #Shift downstream and pull data
+    for (i in 1:max_shift_ds_reaches) {
+      n_alt_ds_reaches = sword$n_rch_dn[sword$reach_id==reach]
+      if(n_alt_ds_reaches==1){    #Do not shift downstream if there is a river junction
+        alt_ds_reach = sword$rch_id_dn[sword$reach_id==reach][1]
+        if (!(alt_ds_reach %in% sword$reach_id)) {  #make sure there's actually a ds reach
+          next   # or break
+        }
+        facc_orig = sword$facc[sword$reach_id==reach] #Get drainage area for orig reach
+        facc_alt = sword$facc[sword$reach_id==alt_ds_reach] #Get drainage area for alt reach
+        orbits_orig = sword$swot_orbits[sword$reach_id==reach] #Get orbits for orig reach
+        orbits_alt = sword$swot_orbits[sword$reach_id==alt_ds_reach] #Get orbits for alt reach
+        
+        #Adjacent reach must have similar contributing drainage area AND identical orbits
+        if(((((facc_alt - facc_orig)/facc_orig)*100) < 10) & (all(orbits_orig == orbits_alt))) {
+          dn_river_pull = try(lapply(alt_ds_reach, pull_data, api_key = api_key))
+          dn_river_filt = lapply(dn_river_pull[!is.na(dn_river_pull)], filter_function)
+          dnObs_alt = rbindlist(dn_river_filt)
+          dnObs_alt$time=as_datetime(dnObs_alt$time_str)
+          dnObs_alt$reach_id_original = dnObs_alt$reach_id
+          dnObs_alt$reach_id = f
+          dnObs_alt$shifted = 'yes'
+          if(nrow(dnObs_alt)>0){
+            return(dnObs_alt)
+          } else{
+            reach = alt_ds_reach
+          }
+        }
       }
-    }
+    } 
   }
-
+  
   additional_ds_obs = rbindlist(lapply(missing_dn, shift_a_reach_away, api_key = api_key))
-
+  
   if (nrow(dnObs_all)==0) {
     dnObs_all= additional_ds_obs
   } else {
@@ -298,45 +344,68 @@ combining_lk_rv_obs = function(lake, api_key){
     dnObs_all = bind_rows(dnObs_all, additional_ds_obs)
   }
   dn_shifted = any(dnObs_all$shifted=='yes')
-
+  
   #Allow upstream reaches to shift one reach upstream.
-  n_us_reaches = updated_pld$D_reach_n[updated_pld$lake_id==lake]
+  n_us_reaches = updated_pld$U_reach_n[updated_pld$lake_id==lake]
   n_us_reaches_obs = upObs_all[,.N,by=reach_id]
   missing_up = upID[upID%!in%n_us_reaches_obs$reach_id]
   shift_a_reach_up = function(f, api_key){
-    print("Shift a reach up")
-
+    print("Shift a reach up...")
+    
     reach_id = as.character(f)
     reach_continent = strtoi(substring(reach_id, 1, 1))
     continent = paste0(sword_continents[reach_continent], "_sword_v", SWORD_VERSION, ".nc")
-
-    sword_nc = nc_open(file.path(dirname(indir), "sword", continent))
+    
+    sword_nc = nc_open(file.path(indir, "sword", continent))
     sword = list(reach_id=ncvar_get(sword_nc, "reaches/reach_id"),
                  rch_id_up=ncvar_get(sword_nc, "reaches/rch_id_up"),
-                 n_rch_up=ncvar_get(sword_nc, "reaches/n_rch_up")
-                 )
+                 n_rch_up=ncvar_get(sword_nc, "reaches/n_rch_up"),
+                 facc=ncvar_get(sword_nc, "reaches/facc"),
+                 swot_orbits=ncvar_get(sword_nc, "reaches/swot_orbits")
+    )
     nc_close(sword_nc)
-
-    n_alt_us_reaches = sword$n_rch_up[sword$reach_id==f]
-    if(n_alt_us_reaches==1){
-      alt_us_reach = sword$rch_id_up[sword$reach_id==f]
-      up_river_pull = try(lapply(alt_us_reach, pull_data, api_key = api_key))
-      up_river_filt = lapply(up_river_pull[!is.na(up_river_pull)], filter_function)
-      upObs_alt = rbindlist(up_river_filt)
-      upObs_alt$time=as_datetime(upObs_alt$time_str)
-      upObs_alt$reach_id_original = upObs_alt$reach_id
-      upObs_alt$reach_id = f
-      upObs_alt$shifted = 'yes'
-      if(nrow(upObs_alt)>0){
-        return(upObs_alt)
+    
+    reach = f
+    
+    #How many reaches can we shift upstream?
+    max_shift_us_reaches = 5
+    
+    #Shift upstream and pull data
+    for (i in 1:max_shift_us_reaches) {
+      n_alt_us_reaches = sword$n_rch_up[sword$reach_id==reach]
+      if(n_alt_us_reaches==1){    #Do not shift upstream if there is a river junction
+        alt_us_reach = sword$rch_id_up[sword$reach_id==reach][1]
+        if (!(alt_us_reach %in% sword$reach_id)) {  #make sure there's actually an us reach
+          next   # or break
+        }
+        facc_orig = sword$facc[sword$reach_id==reach] #Get drainage area for orig reach
+        facc_alt = sword$facc[sword$reach_id==alt_us_reach] #Get drainage area for alt reach
+        orbits_orig = sword$swot_orbits[sword$reach_id==reach] #Get orbits for orig reach
+        orbits_alt = sword$swot_orbits[sword$reach_id==alt_us_reach] #Get orbits for alt reach
+        
+        #Adjacent reach must have similar contributing drainage area AND identical orbits
+        if(((((facc_alt - facc_orig)/facc_orig)*100) < 10) & (all(orbits_orig == orbits_alt))) {
+          up_river_pull = try(lapply(alt_us_reach, pull_data, api_key = api_key))
+          up_river_filt = lapply(up_river_pull[!is.na(up_river_pull)], filter_function)
+          upObs_alt = rbindlist(up_river_filt)
+          upObs_alt$time=as_datetime(upObs_alt$time_str)
+          upObs_alt$reach_id_original = upObs_alt$reach_id
+          upObs_alt$reach_id = f
+          upObs_alt$shifted = 'yes'
+          if(nrow(upObs_alt)>0){
+            return(upObs_alt)
+          } else{
+            reach = alt_us_reach
+          }
+        }
       }
-    }
+    } 
   }
-
+  
   additional_us_obs = rbindlist(lapply(missing_up, shift_a_reach_up, api_key = api_key))
   additional_us_obs$reach_id <- as.character(additional_us_obs$reach_id)
   upObs_all$reach_id <- as.character(upObs_all$reach_id)
-
+  
   
   if (nrow(upObs_all)==0) {
     upObs_all= additional_us_obs
@@ -344,11 +413,11 @@ combining_lk_rv_obs = function(lake, api_key){
     upObs_all = bind_rows(upObs_all, additional_us_obs)
   }
   up_shifted = any(upObs_all$shifted=='yes')
-
-
+  
+  
   lakeObs_all = lakeFilt[lakeFilt$lake_id==lake,]
   lakeObs_all$time = as_datetime(lakeObs_all$time_str)
-
+  
   # FIXME: changing lake areas to pld mean lake areas due to SWOT errors. 
   prior_area = updated_pld$Lake_area[updated_pld$lake_id==lake]
   lakeObs_all$area_total = prior_area
@@ -362,41 +431,45 @@ combining_lk_rv_obs = function(lake, api_key){
   if(nrow(dnObs_all)<1){
     print('nooo down obs... exiting')
     return(NA)}
-
-
+  
+  
   ################################################################################
   # Get dates in proper format and subset to matching dates. 
   ################################################################################
   lakeObs_all$date = as.Date(lakeObs_all$time)
   upObs_all$date = as.Date(upObs_all$time)
   dnObs_all$date = as.Date(dnObs_all$time)
-
+  
   # FIXME: Aggregating lakes to mean values for multiple observations in one day. 
   lakeObs = data.table(lakeObs_all)[,c('wse', 'area_total', 'date')][,lapply(.SD, mean), by=date]
   upObs = data.table(upObs_all)[,c('wse', 'width', 'slope', 'slope2','reach_id', 'date')][,lapply(.SD, mean), by=list(date, reach_id)]
   dnObs = data.table(dnObs_all)[,c('wse', 'width', 'slope', 'slope2','reach_id', 'date')][,lapply(.SD, mean), by=list(date, reach_id)]
-
+  
+  # Reinforce filters after aggregation
+  upObs = upObs[!is.na(slope2) & !is.infinite(slope2) & slope2 > 0 & slope2 != 0 & width > 0]
+  dnObs = dnObs[!is.na(slope2) & !is.infinite(slope2) & slope2 > 0 & slope2 != 0 & width > 0]
+  
   lkDates = unique(lakeObs$date)
   upDts = upObs[,.N,by=date][N>=length(upID)] # limit to dates with obs for each upstream reach.
   dnDts = dnObs[,.N,by=date][N>=length(dnID)] # limit to dates with obs for each downstream reach. 
-
+  
   #goodDates = lkDates[lkDates%in%upObs_all$date&lkDates%in%dnObs_all$date]
   goodDates = lkDates[lkDates%in%upDts$date&lkDates%in%dnDts$date]
-
+  
   lakeObsGood = lakeObs[lakeObs$date%in%goodDates,]
   upObsGood = upObs[upObs$date%in%goodDates,]
   dnObsGood = dnObs[dnObs$date%in%goodDates,]
-
+  
   lakeObs = lakeObsGood[order(lakeObsGood$date),]
   upObs = upObsGood[order(upObsGood$date),]
   dnObs = dnObsGood[order(dnObsGood$date),]
-
-  upObs = upObs[order(upObs$reach_id),]
-  dnObs = dnObs[order(dnObs$reach_id),]
-
+  
+  upObs = upObs[order(reach_id, date)] #recent update
+  dnObs = dnObs[order(reach_id, date)]
+  
   upObs$shifted = up_shifted
   dnObs$shifted = dn_shifted
-
+  
   if(nrow(lakeObs)<4){return(NA)}
   output = list(lakeObs, upObs, dnObs)
   return(output)
@@ -426,71 +499,114 @@ pull_geoglows = function(reaches, start_date='01-01-2023'){
 
 extract_data_by_lake <- function(lake, indir){
   # print("extracting data by lake")
+  
+  # Use dynamic prior Q. False = SOS prior estimate from GRADES / MAF geoglows
+  use_ts_prior=TRUE
+  
+  # Use modeled daily tributary flows. False = mean monthly grades tributaries / MAF geoglows
+  use_ts_tributary=TRUE
+  
+  index=which(names(viable_data)==lake)
+  relevant_data = viable_data[index][[1]]
+  lakeObs = relevant_data[[1]]
+  upObs = relevant_data[[2]]
+  dnObs = relevant_data[[3]]
+  
+  # Extract month and day from observation dates - used to assign et
+  lakeObs$month = month(lakeObs$date)
+  lakeObs$day = day(lakeObs$date)
+  
+  # Find lake depth (heat storage consideration)
+  lake_depth <- et_supplement$Depth_avg[et_supplement$lake_id == lake][1]
+  
+  # Load dynamic ET data
+  if (file.exists(file.path(indir, paste0("/ancillary/et/", lake, ".csv")))) {
+    et = fread(file.path(indir, paste0("/ancillary/et/", lake, ".csv")))
+    et$lake_id = lake
+    et$lake_id = as.character(et$lake_id)
     
-    # Use dynamic prior Q. False = SOS prior estimate from GRADES / MAF geoglows
-    use_ts_prior=TRUE
-  
-    # Use modeled daily tributary flows. False = mean monthly grades tributaries / MAF geoglows
-    use_ts_tributary=TRUE
-  
-    index=which(names(viable_data)==lake)
-    relevant_data = viable_data[index][[1]]
-    lakeObs = relevant_data[[1]]
-    upObs = relevant_data[[2]]
-    dnObs = relevant_data[[3]]
-
-    # Extract month - used to assign et  
-    lakeObs$month = month(lakeObs$date)
-
-    # Add the ET data 
-    et_lake = et[et$lake_id==lake,]
-    if(nrow(et_lake)==0){
-        lakeObs$et = 0
-    }else{
-      et_lake$month = as.numeric(et_lake$month)
-      lakeObs$et = et_lake$mean[match(lakeObs$month, et_lake$month)]
+    # Get lake area for conversion
+    lake_area_m2 = lakeObs$area_total[1] * 1e6 # convert from km2 to m2
+    
+    # Convert evaporation rate of mm/d to m^3/s (depending on lake depth)
+    if (is.na(lake_depth)|| lake_depth >= 5){
+      et[, m3_s := ((E_mm_d_HS * 0.001) * lake_area_m2) / 86400]
+    } else if (lake_depth < 5){
+      et[, m3_s := ((E_mm_d_noHS * 0.001) * lake_area_m2) / 86400]
     }
-
-    # add in tributary data:Either use geoglow (ts==TRUE or use GRADES-hydroDL mean monthly vals)
-    if(use_ts_tributary==TRUE){
-        tributary_locations = tributary[tributary$lake_id==(lake),]
-        if(nrow(tributary_locations)==0){
-            lakeObs$tributary_total=0
-        }else{
-            tributary_reaches = unique(tributary_locations$LINKNO[tributary_locations$lake_id==lake])
-            tributary_reaches = as.list(tributary_reaches)
-            tributary_data = download_tributary(tributary_reaches,'01-01-1940')
-            mean_annual = mean(tributary_data[,year:=lubridate::year(date)][,mean(tributary_total),year]$V1)
-            lakeObs$tributary_total = tributary_data$tributary_total[match(lakeObs$date, tributary_data$date)]
-            }
+    
+  } else {
+    # Create an empty table if the lake does not have dynamic ET data
+    et = data.table()
+  }
+  
+  # Add the ET data to other lake data 
+  if(nrow(et)==0){
+    lakeObs$et = 0
+  }else{
+    lakeObs$et = et$m3_s[match(lakeObs$date, et$date)]
+  }
+  
+  # Fill in missing dates with day-of-year ET means
+  missing <- is.na(lakeObs$et)
+  et_subset <- et_supplement[et_supplement$lake_id == lake, ]
+  
+  # Get lake area for conversion (if needed)
+  lake_area_m2 = lakeObs$area_total[1] * 1e6 # convert from km2 to m2
+  
+  # Convert evaporation rate of mm/d to m^3/s (depending on lake depth)
+  if (is.na(lake_depth)|| lake_depth >= 5){
+    et_subset[, m3_s := ((E_mm_d_HS_mean * 0.001) * lake_area_m2) / 86400]
+  } else if (lake_depth < 5){
+    et_subset[, m3_s := ((E_mm_d_noHS_mean * 0.001) * lake_area_m2) / 86400]
+  }	  
+  
+  # Fill in missing observations
+  lakeObs$et[missing] <- et_subset$m3_s[match(paste(lakeObs$month[missing], lakeObs$day[missing]), paste(et_subset$month, et_subset$day))]	
+  
+  # Remove month and day fields from lakeObs
+  lakeObs[, c("month", "day") := NULL]
+  
+  # add in tributary data:Either use geoglow (ts==TRUE or use GRADES-hydroDL mean monthly vals)
+  if(use_ts_tributary==TRUE){
+    tributary_locations = tributary[tributary$lake_id==(lake),]
+    if(nrow(tributary_locations)==0){
+      lakeObs$tributary_total=0
     }else{
-        tributary_locations = tributary[tributary$lake_id==(lake),]
-        if(nrow(tributary_locations)==0){
-            lakeObs$tributary_total=0
-        }else{
-        tributary_reaches = unique(tributary_locations$LINKNO[tributary_locations$lake_id==lake])
-        tributary_reaches = as.list(tributary_reaches)
-        tributary_data = download_tributary(tributary_reaches,'01-01-1940')
-        mean_annual = mean(tributary_data[,year:=lubridate::year(date)][,mean(tributary_total),year]$V1)
-        lakeObs$tributary_total = mean_annual
-        }
+      tributary_reaches = unique(tributary_locations$LINKNO[tributary_locations$lake_id==lake])
+      tributary_reaches = as.list(tributary_reaches)
+      tributary_data = download_tributary(tributary_reaches,'01-01-1940')
+      mean_annual = mean(tributary_data[,year:=lubridate::year(date)][,mean(tributary_total),year]$V1)
+      lakeObs$tributary_total = tributary_data$tributary_total[match(lakeObs$date, tributary_data$date)]
     }
-
-    # Pull in modeled geoglows data  
-    upID = unlist(strsplit(updated_pld$U_reach_id[updated_pld$lake_id==lake], ','))
-    dnID = unlist(strsplit(updated_pld$D_reach_id[updated_pld$lake_id==lake], ','))
-    sword_reaches = c(upID, dnID)
-    sword_geoglows_filt = sword_geoglows[sword_geoglows$reach_id%in%sword_reaches,c('reach_id','LINKNO')]
-    geoglows_reaches = unique(as.list(sword_geoglows$LINKNO[sword_geoglows$reach_id%in%sword_reaches]))
-    model_data = pull_geoglows(geoglows_reaches, '01-01-1940')
-
-    # Save 
-    fwrite(lakeObs, file.path(indir, paste0("clean/lakeobs_", lake, ".csv")))
-    fwrite(upObs, file.path(indir, paste0("clean/upobs_", lake, ".csv")))
-    fwrite(dnObs,file.path(indir, paste0("clean/dnobs_", lake, ".csv") ))
-    fwrite(model_data,file.path(indir,paste0("clean/geoglows_", lake, ".csv")) )
-
-    return()
+  }else{
+    tributary_locations = tributary[tributary$lake_id==(lake),]
+    if(nrow(tributary_locations)==0){
+      lakeObs$tributary_total=0
+    }else{
+      tributary_reaches = unique(tributary_locations$LINKNO[tributary_locations$lake_id==lake])
+      tributary_reaches = as.list(tributary_reaches)
+      tributary_data = download_tributary(tributary_reaches,'01-01-1940')
+      mean_annual = mean(tributary_data[,year:=lubridate::year(date)][,mean(tributary_total),year]$V1)
+      lakeObs$tributary_total = mean_annual
+    }
+  }
+  
+  # Pull in modeled geoglows data  
+  upID = unlist(strsplit(updated_pld$U_reach_id[updated_pld$lake_id==lake], ','))
+  dnID = unlist(strsplit(updated_pld$D_reach_id[updated_pld$lake_id==lake], ','))
+  sword_reaches = c(upID, dnID)
+  sword_geoglows_filt = sword_geoglows[sword_geoglows$reach_id%in%sword_reaches,c('reach_id','LINKNO')]
+  geoglows_reaches = unique(as.list(sword_geoglows$LINKNO[sword_geoglows$reach_id%in%sword_reaches]))
+  model_data = pull_geoglows(geoglows_reaches, '01-01-1940')
+  
+  # Save 
+  fwrite(lakeObs, file.path(indir, paste0("clean/lakeobs_", lake, ".csv")))
+  fwrite(upObs, file.path(indir, paste0("clean/upobs_", lake, ".csv")))
+  fwrite(dnObs,file.path(indir, paste0("clean/dnobs_", lake, ".csv") ))
+  fwrite(model_data,file.path(indir,paste0("clean/geoglows_", lake, ".csv")) )
+  
+  return()
 }
 
 
@@ -524,7 +640,15 @@ combined = rbindlist(files_filt[!is.na(files_filt)])
 # Filter lake data
 ################################################################################
 # Testing to see if partial flags make a difference since we're only using wse for lakes at the moment. - partial wse seems great. 
-lakeData = combined[combined$ice_clim_f<2&combined$dark_frac<=0.5&combined$xovr_cal_q<2&combined$time_str!='no_data'&combined$wse>(5000*-1),]
+#lakeData = combined[combined$ice_clim_f<2&combined$dark_frac<=0.5&combined$xovr_cal_q<2&combined$time_str!='no_data'&combined$wse>(5000*-1),]
+lakeData = combined[combined$ice_clim_f <= 1 &
+                      combined$dark_frac <= 0.6 &
+                      combined$xovr_cal_q <= 1 &
+                      combined$quality_f <= 2 &
+                      combined$partial_f <= 0 &
+                      ((combined$xtrk_dist >= 10000 & combined$xtrk_dist <= 60000) | (combined$xtrk_dist >= -60000 & combined$xtrk_dist <= -10000)) &
+                      combined$time_str!='no_data' &
+                      combined$wse>(5000*-1),]
 lakeData = lakeData%>%distinct(.keep_all=TRUE)
 lakeData$lake_id = as.character(lakeData$lake_id)
 
@@ -571,7 +695,7 @@ if (nrow(viable_locations) == 0){
 
 for(i in 1:nrow(viable_locations)){
   # print(viable_locations)
-    extract_data_by_lake(viable_locations$lake[i], indir)
+  extract_data_by_lake(viable_locations$lake[i], indir)
 }
 
 ################################################################################
@@ -581,5 +705,5 @@ for(i in 1:nrow(viable_locations)){
 dir.create(file.path(indir, "viable"), showWarnings = FALSE)
 numbers <- gregexpr("[0-9]+", basename(opts$input_file))
 result <- unlist(regmatches(basename(opts$input_file), numbers))
-fwrite(viable_locations[,"lake"], file.path(indir, paste0("viable/viable_locations.csv")))
+fwrite(viable_locations[,"lake"], file.path(indir, paste0("viable/viable_locations", index, ".csv")))
 print('Found viable lakes...')

--- a/src/lakeflow_1.R
+++ b/src/lakeflow_1.R
@@ -35,16 +35,13 @@ use_python("/usr/local/bin/python3.12")
 #use_virtualenv("r-reticulate")
 
 ################################################################################
-# Constants
-
-SWORD_VERSION = "17"
-
-################################################################################
 # Set args
 option_list <- list(
   make_option(c("-c", "--input_file"), type = "character", default = NULL, help = "filepath to csv with lake ids to download data, point it to reaches_of_interest.json to process lakes associated with those reaches"),
   make_option(c("-w", "--workers"), type = "integer", default = NULL, help = "number of workers to use to download swot data"),
   make_option(c("-i", "--indir"), type = "character", default = NULL , help = "directory with input files"),
+  make_option(c("-s", "--sword_dir"), type = "character", default = NULL, help = "filepath for sword network"),
+  make_option(c("-v", "--swordversion"), type = "character", default = "17", help = "version of sword we are using"),
   make_option(c("-p", "--prefix"), type = "character", default = "", help = "prefix for hydrocron api-key storage")
   ## I had an index argument, but the script is actually faster in seriel instead of calling hydrocron in parallel
   # make_option(c("--index"), type = "integer", default = NULL , help = "Chooses what lake to process from input file, if -256 it uses array number")
@@ -61,6 +58,12 @@ workers_ <- opts$workers
 
 # Path that holds input data, was previously 'in'
 indir <- opts$indir
+
+# Path to SWORD nc files
+sword_dir <- opts$sword_dir
+
+# SWORD product version
+SWORD_VERSION <- opts$swordversion
 
 # Prefix for hydrocron API in the parameter store
 prefix <- opts$prefix
@@ -81,6 +84,10 @@ prefix <- opts$prefix
 updated_pld = fread(file.path(indir,"/SWORDv17b_PLDv201.csv"))
 updated_pld$lake_id =  as.character(updated_pld$lake_id)
 updated_pld$continent = substr(updated_pld$lake_id, 1,1)
+
+# Load ET data
+et = fread(file.path(indir, '/ancillary/et.csv'))
+et$lake_id <- as.character(et$lake_id)
 
 # Load supplementary ET dataset
 et_supplement = fread(file.path(indir, '/ancillary/et_supplement.csv'))
@@ -288,7 +295,7 @@ combining_lk_rv_obs = function(lake, api_key){
     reach_continent = strtoi(substring(reach_id, 1, 1))
     continent = paste0(sword_continents[reach_continent], "_sword_v", SWORD_VERSION, ".nc")
     
-    sword_nc = nc_open(file.path(indir, "sword", continent))
+    sword_nc = nc_open(file.path(sword_dir, continent))
     sword = list(reach_id=ncvar_get(sword_nc, "reaches/reach_id"),
                  rch_id_dn=ncvar_get(sword_nc, "reaches/rch_id_dn"),
                  n_rch_dn=ncvar_get(sword_nc, "reaches/n_rch_down"),
@@ -356,7 +363,7 @@ combining_lk_rv_obs = function(lake, api_key){
     reach_continent = strtoi(substring(reach_id, 1, 1))
     continent = paste0(sword_continents[reach_continent], "_sword_v", SWORD_VERSION, ".nc")
     
-    sword_nc = nc_open(file.path(indir, "sword", continent))
+    sword_nc = nc_open(file.path(sword_dir, continent))
     sword = list(reach_id=ncvar_get(sword_nc, "reaches/reach_id"),
                  rch_id_up=ncvar_get(sword_nc, "reaches/rch_id_up"),
                  n_rch_up=ncvar_get(sword_nc, "reaches/n_rch_up"),
@@ -520,31 +527,23 @@ extract_data_by_lake <- function(lake, indir){
   lake_depth <- et_supplement$Depth_avg[et_supplement$lake_id == lake][1]
   
   # Load dynamic ET data
-  if (file.exists(file.path(indir, paste0("/ancillary/et/", lake, ".csv")))) {
-    et = fread(file.path(indir, paste0("/ancillary/et/", lake, ".csv")))
-    et$lake_id = lake
-    et$lake_id = as.character(et$lake_id)
-    
+  et_lake = et[et$lake_id==lake,]
+  
+  if(nrow(et_lake)==0){
+    lakeObs$et = 0
+  }else{
     # Get lake area for conversion
     lake_area_m2 = lakeObs$area_total[1] * 1e6 # convert from km2 to m2
     
     # Convert evaporation rate of mm/d to m^3/s (depending on lake depth)
     if (is.na(lake_depth)|| lake_depth >= 5){
-      et[, m3_s := ((E_mm_d_HS * 0.001) * lake_area_m2) / 86400]
+      et_lake[, m3_s := ((E_mm_d_HS * 0.001) * lake_area_m2) / 86400]
     } else if (lake_depth < 5){
-      et[, m3_s := ((E_mm_d_noHS * 0.001) * lake_area_m2) / 86400]
+      et_lake[, m3_s := ((E_mm_d_noHS * 0.001) * lake_area_m2) / 86400]
     }
     
-  } else {
-    # Create an empty table if the lake does not have dynamic ET data
-    et = data.table()
-  }
-  
-  # Add the ET data to other lake data 
-  if(nrow(et)==0){
-    lakeObs$et = 0
-  }else{
-    lakeObs$et = et$m3_s[match(lakeObs$date, et$date)]
+    # Match by date
+    lakeObs$et = et_lake$m3_s[match(lakeObs$date, et_lake$date)]
   }
   
   # Fill in missing dates with day-of-year ET means

--- a/src/lakeflow_1.R
+++ b/src/lakeflow_1.R
@@ -45,7 +45,7 @@ option_list <- list(
   make_option(c("-c", "--input_file"), type = "character", default = NULL, help = "filepath to csv with lake ids to download data, point it to reaches_of_interest.json to process lakes associated with those reaches"),
   make_option(c("-w", "--workers"), type = "integer", default = NULL, help = "number of workers to use to download swot data"),
   make_option(c("-i", "--indir"), type = "character", default = NULL , help = "directory with input files"),
-  make_option(c("-p", "--prefix"), type = "character", default = "", help = "prefix for hydrocron api-key storage"),
+  make_option(c("-p", "--prefix"), type = "character", default = "", help = "prefix for hydrocron api-key storage")
   ## I had an index argument, but the script is actually faster in seriel instead of calling hydrocron in parallel
   # make_option(c("--index"), type = "integer", default = NULL , help = "Chooses what lake to process from input file, if -256 it uses array number")
 )

--- a/src/lakeflow_1.R
+++ b/src/lakeflow_1.R
@@ -47,7 +47,7 @@ option_list <- list(
   make_option(c("-i", "--indir"), type = "character", default = NULL , help = "directory with input files"),
   make_option(c("-p", "--prefix"), type = "character", default = "", help = "prefix for hydrocron api-key storage"),
   ## I had an index argument, but the script is actually faster in seriel instead of calling hydrocron in parallel
-  make_option(c("--index"), type = "integer", default = NULL , help = "Chooses what lake to process from input file, if -256 it uses array number")
+  # make_option(c("--index"), type = "integer", default = NULL , help = "Chooses what lake to process from input file, if -256 it uses array number")
 )
 ################################################################################
 
@@ -65,13 +65,13 @@ indir <- opts$indir
 # Prefix for hydrocron API in the parameter store
 prefix <- opts$prefix
 
-# Set index, use array if index is -256
-index <- opts$index
-if (index == -256){
-  index <- strtoi(Sys.getenv("SLURM_ARRAY_TASK_ID"))
-}
-
-cat("SLURM_ARRAY_TASK_ID inside R:", Sys.getenv("SLURM_ARRAY_TASK_ID"), "\n")
+# # Set index, use array if index is -256
+# index <- opts$index
+# if (index == -256){
+#   index <- strtoi(Sys.getenv("SLURM_ARRAY_TASK_ID"))
+# }
+# 
+# cat("SLURM_ARRAY_TASK_ID inside R:", Sys.getenv("SLURM_ARRAY_TASK_ID"), "\n")
 
 ################################################################################
 # Load datasets
@@ -705,5 +705,5 @@ for(i in 1:nrow(viable_locations)){
 dir.create(file.path(indir, "viable"), showWarnings = FALSE)
 numbers <- gregexpr("[0-9]+", basename(opts$input_file))
 result <- unlist(regmatches(basename(opts$input_file), numbers))
-fwrite(viable_locations[,"lake"], file.path(indir, paste0("viable/viable_locations", index, ".csv")))
+fwrite(viable_locations[,"lake"], file.path(indir, paste0("viable/viable_locations.csv")))
 print('Found viable lakes...')

--- a/src/lakeflow_1.R
+++ b/src/lakeflow_1.R
@@ -87,11 +87,11 @@ et_supplement = fread(file.path(indir, '/ancillary/et_supplement.csv'))
 et_supplement$lake_id <- as.character(et_supplement$lake_id)
 
 # Load tributary dataset
-tributary = fread(file.path(indir,'/ancillary/tributaries_w_ghost_reach.csv'))
+tributary = fread(file.path(indir,'/ancillary/tributaries.csv'))
 tributary$lake_id <- as.character(tributary$lake_id)
 
 # Load geoglows dataset
-sword_geoglows = fread(file.path(indir,'/ancillary/sword_geoglows_w_ghost_reach.csv'))
+sword_geoglows = fread(file.path(indir,'/ancillary/sword_geoglows.csv'))
 sword_geoglows$reach_id = as.character(sword_geoglows$reach_id)
 
 # Create a folder to store the downloaded/processed datasets

--- a/src/lakeflow_1_submit.sh
+++ b/src/lakeflow_1_submit.sh
@@ -21,4 +21,4 @@ apptainer exec \
     --bind /projects/swot/hana/LakeFlow_Confluence \
     --cleanenv \
     --env SLURM_ARRAY_TASK_ID=$SLURM_ARRAY_TASK_ID \
-    /projects/swot/hana/LakeFlow_Confluence/lakeflow_input.sif Rscript src/lakeflow_1.R -c "in/lakeids/lakeid${SLURM_ARRAY_TASK_ID}.csv" -w 1 -i in/ --index -256
+    /projects/swot/hana/LakeFlow_Confluence/lakeflow_input.sif Rscript src/lakeflow_1.R -c "in/lakeids/lakeid${SLURM_ARRAY_TASK_ID}.csv" -w 1 -i in/ -s in/sword/ -v 17 --index -256

--- a/src/lakeflow_1_submit.sh
+++ b/src/lakeflow_1_submit.sh
@@ -8,16 +8,17 @@
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem-per-cpu=5GB
-#SBATCH --time 3:00:00
+#SBATCH --time 5:00:00
 #SBATCH -p normal_q
 #SBATCH -A swot
 #SBATCH --array=1-50
 ####### end of job customization
 # end of environment & variable setup
 
-module load containers/apptainer
+module load apptainer/1.4.0
 apptainer exec \
     --pwd /projects/swot/hana/LakeFlow_Confluence \
     --bind /projects/swot/hana/LakeFlow_Confluence \
     --cleanenv \
-    /projects/swot/hana/LakeFlow_Confluence/lakeflow.sif Rscript src/lakeflow_1.R "in/lakeids/lakeid${SLURM_ARRAY_TASK_ID}.csv" 1
+    --env SLURM_ARRAY_TASK_ID=$SLURM_ARRAY_TASK_ID \
+    /projects/swot/hana/LakeFlow_Confluence/lakeflow_input.sif Rscript src/lakeflow_1.R -c "in/lakeids/lakeid${SLURM_ARRAY_TASK_ID}.csv" -w 1 -i in/ --index -256

--- a/src/lakeflow_2.R
+++ b/src/lakeflow_2.R
@@ -31,13 +31,13 @@ library(optparse)
 ################################################################################
 # Set args
 option_list <- list(
-    make_option(c("-c", "--input_file"), type = "character", default = NULL, help = "filepath for a list of lakes to run lakeflow"),
-    make_option(c("-s", "--sos_dir"), type = "character", default = NULL, help = "filepath for the sos"),
-    make_option(c("-w", "--workers"), type = "integer", default = NULL, help = "number of cores for lakeflow to use"),
-    make_option(c("-i", "--indir"), type = "character", default = NULL , help = "directory with input files"),
-    make_option(c("-o", "--outdir"), type = "character", default = NULL , help = "directory to output results"),
-    make_option(c("--index"), type = "integer", default = NULL, help = "index of what lake to process in the input file if blank process whole file")
-  )
+  make_option(c("-c", "--input_file"), type = "character", default = NULL, help = "filepath for a list of lakes to run lakeflow"),
+  make_option(c("-s", "--sos_dir"), type = "character", default = NULL, help = "filepath for the sos"),
+  make_option(c("-w", "--workers"), type = "integer", default = NULL, help = "number of cores for lakeflow to use"),
+  make_option(c("-i", "--indir"), type = "character", default = NULL , help = "directory with input files"),
+  make_option(c("-o", "--outdir"), type = "character", default = NULL , help = "directory to output results"),
+  make_option(c("--index"), type = "integer", default = NULL, help = "index of what lake to process in the input file if blank process whole file")
+)
 ################################################################################
 
 # Grab arguments
@@ -68,23 +68,23 @@ outdir <- opts$outdir
 index <- opts$index
 
 if (!(is.null(index))){
-    if (index == -256){
+  if (index == -256){
     index <- strtoi(Sys.getenv("AWS_BATCH_JOB_ARRAY_INDEX")) + 1
-    }
-    else{
-        index <- index + 1
-    }
+  }
+  else{
+    index <- index + 1
+  }
 }
 
 ################################################################################
 # Load datasets 
 ################################################################################
 
-updated_pld = fread(file.path(indir,"SWORDv16_PLDv103_wo_ghost_rch.csv"))
+updated_pld = fread(file.path(indir,"SWORDv17b_PLDv201.csv"))
 updated_pld$lake_id =  as.character(updated_pld$lake_id)
 updated_pld$continent = substr(updated_pld$lake_id, 1,1)
 
-sword_geoglows = fread(file.path(indir,'ancillary/sword_geoglows.csv'))
+sword_geoglows = fread(file.path(indir,'ancillary/sword_geoglows_w_ghost_reach.csv'))
 sword_geoglows$reach_id = as.character(sword_geoglows$reach_id)
 
 ################################################################################
@@ -92,485 +92,485 @@ sword_geoglows$reach_id = as.character(sword_geoglows$reach_id)
 ################################################################################
 
 lakeFlow = function(lake){
+  
+  # Use dynamic prior Q. False = SOS prior estimate from GRADES / MAF geoglows
+  use_ts_prior=TRUE
+  
+  # Use modeled daily tributary flows. False = mean monthly grades tributaries / MAF geoglows
+  use_ts_tributary=TRUE
+  
+  lakeObs <- fread(file.path(indir, paste0("clean/lakeobs_", lake, ".csv")))
+  upObs <- fread(file.path(indir, paste0("clean/upobs_", lake, ".csv")))
+  upObs$reach_id <- as.character(upObs$reach_id)
+  dnObs <- fread(file.path(indir, paste0("clean/dnobs_", lake, ".csv")))
+  dnObs$reach_id <- as.character(dnObs$reach_id)
+  
+  upID = unlist(strsplit(updated_pld$U_reach_id[updated_pld$lake_id==lake], ','))
+  dnID = unlist(strsplit(updated_pld$D_reach_id[updated_pld$lake_id==lake], ','))
+  
+  d_x_area = function(wse, width){
+    wse_from_min = wse - min(wse)
+    x_area = width * wse_from_min
+    area_dt = c(NA, diff(x_area))
+    return(x_area)
+  }
+  
+  # Apply d_x_area function from above. 
+  upObs$d_x_area = upObs[,d_x_area(wse, width),by=reach_id]$V1
+  dnObs$d_x_area = dnObs[,d_x_area(wse, width), by=reach_id]$V1
+  
+  # Calculate lake storage and storage change
+  lake_wse_from_min = lakeObs$wse - min(lakeObs$wse)
+  area_m2 = lakeObs$area_total * 1e6 # convert from km2 to m2
+  lakeObs$storage = area_m2 * lake_wse_from_min
+  ht_change = c(NA, diff(lakeObs$wse))
+  area_m2 = lakeObs$area_total*1e6
+  
+  area_val = list()
+  for(k in 2:length(area_m2)){
+    current = area_m2[k]
+    prior = area_m2[k-1]
+    area_add = current+prior
+    area_mult= current*prior
+    area_sqrt = sqrt(area_mult)
+    area_val[[k]] = area_add+area_sqrt
+  }
+  area_param = c(NA, unlist(area_val))
+  lakeObs$storage_dt = (ht_change*area_param)/3
+  
+  # Put data into table matching LakeFlow code (synthetic dataset): 
+  lakeObsOut = lakeObs
+  upObsOut = upObs
+  dnObsOut = dnObs
+  names(lakeObsOut) = c("date_l", "wse_l", "area_total_l", "et", "tributary_total", "storage_l", "storage_dt_l")
+  names(upObsOut) = paste0(names(upObs), "_u")
+  names(dnObsOut) = paste0(names(dnObs), "_d")
+  
+  # Split dataframes by group into lists of dataframes.  
+  up_df_list = split(upObsOut, by='reach_id_u')
+  dn_df_list = split(dnObsOut, by='reach_id_d')
+  
+  # n days between observations. 
+  lakeObsOut$n_days = c(NA, as.numeric(diff(lakeObsOut$date_l)))
+  
+  # Remove first day from all dataframes bc dv is missing. 
+  lakeObsOut = lakeObsOut[-1,]
+  up_df_list = lapply(up_df_list, function(f) f[-1,])
+  dn_df_list = lapply(dn_df_list, function(f) f[-1,])
+  
+  # Transpose the data to get in proper format for stan. 
+  up_df_wide = lapply(up_df_list, t)
+  dn_df_wide = lapply(dn_df_list, t)
+  
+  # Combine the swot obs of multiple reaches back together.  
+  up_df_out = do.call('rbind', up_df_wide)
+  dn_df_out = do.call('rbind', dn_df_wide)
+  
+  # Create seperate matrices for each type of swot obs. Time across, reach down
+  up_df_stan = lapply(names(upObsOut)[-1], function(f) as.matrix(up_df_out[grep(f,rownames(up_df_out)),]))
+  names(up_df_stan) = names(upObsOut)[-1]
+  up_df_stan = lapply(up_df_stan, apply, 2, as.numeric)
+  
+  dn_df_stan = lapply(names(dnObsOut)[-1], function(f) as.matrix(dn_df_out[grep(f,rownames(dn_df_out)),]))
+  names(dn_df_stan) = names(dnObsOut)[-1]
+  dn_df_stan = lapply(dn_df_stan, apply, 2, as.numeric)
+  
+  transposer <- function(df) {
+    z<-t(df)
+  }
+  
+  # If reach is only one value, transpose the data to match multiple inflow/outflow setups. 
+  if(length(upID)==1){
+    up_df_stan = lapply(up_df_stan, transposer)
+  }
+  
+  if(length(dnID)==1){
+    dn_df_stan = lapply(dn_df_stan, transposer)
+  }
+  
+  # dA shift function. 
+  da_shift_fun = function(x) median(x) - min(x)
+  
+  # dA scale to be greater than 0.
+  da_scale = function(x) x - min(x)
+  
+  # Apply the above functions. 
+  up_da_shift = array(apply(up_df_stan$d_x_area_u,1, da_shift_fun))
+  d_x_area_scaled_u = t(as.matrix(apply(up_df_stan$d_x_area_u, 1, da_scale)))
+  
+  dn_da_shift = array(apply(dn_df_stan$d_x_area_d,1, da_shift_fun))
+  d_x_area_scaled_d = t(as.matrix(apply(dn_df_stan$d_x_area_d, 1, da_scale)))
+  
+  # Function to extract priors from SOS. 
+  sos_pull = function(reach_id){
+    #sos = "sos/constrained/na_sword_v15_SOS_priors.nc"
+    #sos_outflow = RNetCDF::open.nc(sos)
+    #sos = "in/sos/constrained/na_sword_v15_SOS_priors.nc"
+    if (updated_pld$continent[updated_pld$lake_id==lake] == 1) {
+      sos = file.path(sos_dir, "af_sword_v17_SOS_priors.nc")
+    } else if (updated_pld$continent[updated_pld$lake_id==lake] == 2) {
+      sos = file.path(sos_dir, "eu_sword_v17_SOS_priors.nc")
+    } else if (updated_pld$continent[updated_pld$lake_id==lake] == 3) {
+      sos = file.path(sos_dir, "as_sword_v17_SOS_priors.nc")
+    } else if (updated_pld$continent[updated_pld$lake_id==lake] == 4) {
+      sos = file.path(sos_dir, "as_sword_v17_SOS_priors.nc")
+    } else if (updated_pld$continent[updated_pld$lake_id==lake] == 5) {
+      sos = file.path(sos_dir, "oc_sword_v17_SOS_priors.nc")
+    } else if (updated_pld$continent[updated_pld$lake_id==lake] == 6) {
+      sos = file.path(sos_dir, "sa_sword_v17_SOS_priors.nc")
+    } else {sos = file.path(sos_dir, "na_sword_v17_SOS_priors.nc")} #Sets NA priors for continents 7, 8, and 9
+    sos_outflow = RNetCDF::open.nc(sos)
+    reach_grp <- RNetCDF::grp.inq.nc(sos_outflow, "reaches")$self
+    reach_ids <- RNetCDF::var.get.nc(reach_grp, "reach_id")
+    index <- which(reach_ids==reach_id, arr.ind=TRUE)
+    gbp_grp <- RNetCDF::grp.inq.nc(sos_outflow, "gbpriors/reach")$self
+    geoA = RNetCDF::var.get.nc(gbp_grp, "logA0_hat")[index]
+    geoN = RNetCDF::var.get.nc(gbp_grp, "logn_hat")[index]
+    geoNlower = RNetCDF::var.get.nc(gbp_grp, "lowerbound_logn")[index]
+    geoNupper = RNetCDF::var.get.nc(gbp_grp, "upperbound_logn")[index]
+    geoAlower = RNetCDF::var.get.nc(gbp_grp, "lowerbound_A0")[index]
+    geoAupper = RNetCDF::var.get.nc(gbp_grp, "upperbound_A0")[index]
+    geoAsd = RNetCDF::var.get.nc(gbp_grp, "logA0_sd")[index]
+    geoNsd = RNetCDF::var.get.nc(gbp_grp, "logn_sd")[index]
+    model_grp <- RNetCDF::grp.inq.nc(sos_outflow, "model")$self
+    qHat <- RNetCDF::var.get.nc(model_grp, "mean_q")[index]
+    #Assign a prior of 1000 cms is q prior is NA. - probably makes sense to use some relationship between width and meanQ in the future.   
+    qHat = ifelse(is.na(qHat), 1000, qHat)
+    qUpper <- RNetCDF::var.get.nc(model_grp, "max_q")[index]
+    qLower <- RNetCDF::var.get.nc(model_grp, "min_q")[index]
+    qLower = ifelse(qLower<=0|is.na(qLower), 0.001, qLower)
+    qUpper = ifelse(is.na(qUpper),500000, qUpper)
+    sigma = RNetCDF::var.get.nc(gbp_grp, "sigma_man")[index]
+    qSd=RNetCDF::var.get.nc(gbp_grp, "logQ_sd")[index]
+    return(data.table(reach_id, geoA, geoN, geoNlower, geoNupper, geoAlower, geoAupper,
+                      geoAsd, geoNsd, qHat, qUpper, qLower, sigma, qSd))
+  }
+  
+  # Create our own geobam priors when SoS provides null priors - common issue bc lake influenced reaches often don't pass SoS QAQC.
+  sos_fit = function(df){
+    reach_id = unique(unlist(df[grep('reach_id', names(df))]))#[[1]]
+    width_matrix = df[grep('width', names(df))][[1]]
+    slope_matrix = df[grep('slope2', names(df))][[1]]
+    geoA = estimate_logA0(width_matrix)
+    geoN = estimate_logn(slope_matrix, width_matrix)
+    geoNlower = estimate_lowerboundlogn(width_matrix)
+    geoNupper = estimate_upperboundlogn(width_matrix)
+    geoAlower = estimate_lowerboundA0(width_matrix)
+    geoAupper = estimate_upperboundA0(width_matrix)
+    geoAsd = estimate_A0SD(width_matrix)
+    geoNsd = estimate_lognSD(width_matrix)
+    #Talk to Craig about more informed estimates of the below. 
+    qHat = rep(NA, length(reach_id))
+    qLower = rep(NA, length(reach_id))
+    qUpper = rep(NA, length(reach_id))
+    qSd = rep(100, length(reach_id))
+    sigma = rep(0.25, length(reach_id))
+    #Assign a prior of 1000 cms is q prior is NA. - probably makes sense to use some relationship between width and meanQ in the future.   
+    qHat = ifelse(is.na(qHat), 1000, qHat)
+    qLower = ifelse(qLower<=0|is.na(qLower), 0.001, qLower)
+    qUpper = ifelse(is.na(qUpper),500000, qUpper)
+    return(list(data.table(reach_id, geoA, geoN, geoNlower, geoNupper, geoAlower, geoAupper,
+                           geoAsd, geoNsd, qHat, qUpper, qLower, sigma, qSd)))
+  }
+  
+  # Add u and d labels to each column of sos outputs - helps with organizing the data. 
+  nms_paste = function(df, added_label){
+    nms = colnames(df)
+    new_nms = paste0(nms, '_', added_label)
+    colnames(df) = new_nms
+    return(df)
+  }
+  
+  # Pull priors from sos 
+  #New 'any(is.na)...' is new to account for NA values in addition to zeros. 
+  up_sos = lapply(upID, sos_pull)
+  sos_geobam = 'sos'
+  if(any(unlist(lapply(up_sos, nrow))==0)|any(is.na(unlist(up_sos)))){
+    up_sos = sos_fit(up_df_stan)
+    sos_geobam = 'geobam'
+  }
+  up_sos = lapply(up_sos, nms_paste, 'u')
+  
+  dn_sos = lapply(dnID, sos_pull)
+  if(any(unlist(lapply(dn_sos, nrow))==0)|any(is.na(unlist(dn_sos)))){
+    dn_sos = sos_fit(dn_df_stan)
+    sos_geobam = 'geobam'
+  }
+  dn_sos = lapply(dn_sos, nms_paste, 'd')
+  
+  # Transpose the sos data to get in proper format for stan. 
+  up_sos_wide = lapply(up_sos, t)
+  dn_sos_wide = lapply(dn_sos, t)
+  
+  # Combine the sos priors of multiple reaches together.  
+  up_sos_out = do.call('rbind', up_sos_wide)
+  dn_sos_out = do.call('rbind', dn_sos_wide)
+  
+  # Create seperate matrices for each type of sos prior. reach down time across. 
+  up_sos_stan = lapply(colnames(up_sos[[1]]), function(f) as.matrix(up_sos_out[grep(f,rownames(up_sos_out)),]))
+  names(up_sos_stan) = colnames(up_sos[[1]])
+  up_sos_stan = lapply(up_sos_stan, apply, 2, as.numeric)
+  
+  dn_sos_stan = lapply(colnames(dn_sos[[1]]), function(f) as.matrix(dn_sos_out[grep(f,rownames(dn_sos_out)),]))
+  names(dn_sos_stan) = colnames(dn_sos[[1]])
+  dn_sos_stan = lapply(dn_sos_stan, apply, 2, as.numeric)
+  
+  # Place in array to meet stan needs. 
+  up_sos_stan = lapply(up_sos_stan, array)
+  dn_sos_stan = lapply(dn_sos_stan, array)
+  
+  # Create matrix for select priors that need to be length of obs for stan. 
+  convert_to_matrix = function(f){
+    n = length(f)
+    output = apply(f, 1, rep, nrow(lakeObsOut))
+    return(t(output))
+  }
+  
+  up_sos_stan$sigma_u=convert_to_matrix(up_sos_stan$sigma_u)
+  dn_sos_stan$sigma_d=convert_to_matrix(dn_sos_stan$sigma_d)
+  up_sos_stan$qSd_u = convert_to_matrix(up_sos_stan$qSd_u)
+  dn_sos_stan$qSd_d = convert_to_matrix(dn_sos_stan$qSd_d)
+  up_sos_stan$qHat_u = convert_to_matrix(up_sos_stan$qHat_u)
+  dn_sos_stan$qHat_d = convert_to_matrix(dn_sos_stan$qHat_d)
+  
+  if(length(up_sos_stan$reach_id_u)==0){return(NA)}
+  if(length(dn_sos_stan$reach_id_d)==0){return(NA)}
+  
+  
+  # Pull in Modeled timeseries as prior Q rather than mean: #Updating alternative to using static Geoglows mean annual flow. 
+  if(use_ts_prior==TRUE){
+    #sword_geoglows = fread(paste0(inPath, '/ancillary/sword_geoglows.csv'))
+    sword_reaches = c(upID, dnID)
+    #sword_geoglows$reach_id = as.character(sword_geoglows$reach_id)
+    sword_geoglows_filt = sword_geoglows[sword_geoglows$reach_id%in%sword_reaches,c('reach_id','LINKNO')]
+    geoglows_reaches = unique(as.list(sword_geoglows$LINKNO[sword_geoglows$reach_id%in%sword_reaches]))
+    # Pull in modeled geoglows data. 
+    #model_data = pull_geoglows(geoglows_reaches, '01-01-1940')
+    model_data <- fread(file.path(indir,paste0("clean/geoglows_", lake, ".csv")))
+    model_data$Date <- as.Date(model_data$Date)
+    # Convert bad Q to NA. 
+    ind = ncol(model_data)-1
+    model_data[,1:ind][model_data[,1:ind] < 0] <- 0.1
+    # When model data is unavailable (NRT SWOT data), use mean model. 
+    missing_dates = data.table(Date=seq.Date((max(model_data$Date)+1), Sys.Date(), by=1))
+    model_data = bind_rows(model_data, missing_dates)
+    model_data[] <- lapply(model_data, function(x) { 
+      x[is.na(x)] <- mean(x, na.rm = TRUE)
+      x})
+    model_data_all = model_data
+    model_data = model_data[model_data$Date%in%lakeObsOut$date_l,]
+    model_wide = melt(model_data, id.vars=c('Date'))
+    model_wide$LINKNO = as.character(model_wide$variable)
+    model_wide$reach_id = sword_geoglows_filt$reach_id[match(model_wide$LINKNO, sword_geoglows_filt$LINKNO)]
+    model_list = split(model_wide, by='reach_id')
     
-    # Use dynamic prior Q. False = SOS prior estimate from GRADES / MAF geoglows
-    use_ts_prior=TRUE
+    up_ind = lapply(up_sos_stan$reach_id_u,function(x){which(as.character(x)==names(model_list))})
+    dn_ind = lapply(dn_sos_stan$reach_id_d,function(x){which(as.character(x)==names(model_list))})
     
-    # Use modeled daily tributary flows. False = mean monthly grades tributaries / MAF geoglows
-    use_ts_tributary=TRUE
-
-    lakeObs <- fread(file.path(indir, paste0("clean/lakeobs_", lake, ".csv")))
-    upObs <- fread(file.path(indir, paste0("clean/upobs_", lake, ".csv")))
-    upObs$reach_id <- as.character(upObs$reach_id)
-    dnObs <- fread(file.path(indir, paste0("clean/dnobs_", lake, ".csv")))
-    dnObs$reach_id <- as.character(dnObs$reach_id)
-    
-    upID = unlist(strsplit(updated_pld$U_reach_id[updated_pld$lake_id==lake], ','))
-    dnID = unlist(strsplit(updated_pld$D_reach_id[updated_pld$lake_id==lake], ','))
-    
-    d_x_area = function(wse, width){
-        wse_from_min = wse - min(wse)
-        x_area = width * wse_from_min
-        area_dt = c(NA, diff(x_area))
-        return(x_area)
+    if(length(unique(model_wide$LINKNO))==1){
+      up_ind[[1]] = 1
+      dn_ind[[1]] = 1
     }
-  
-    # Apply d_x_area function from above. 
-    upObs$d_x_area = upObs[,d_x_area(wse, width),by=reach_id]$V1
-    dnObs$d_x_area = dnObs[,d_x_area(wse, width), by=reach_id]$V1
-  
-    # Calculate lake storage and storage change
-    lake_wse_from_min = lakeObs$wse - min(lakeObs$wse)
-    area_m2 = lakeObs$area_total * 1e6 # convert from km2 to m2
-    lakeObs$storage = area_m2 * lake_wse_from_min
-    ht_change = c(NA, diff(lakeObs$wse))
-    area_m2 = lakeObs$area_total*1e6
-
-    area_val = list()
-    for(k in 2:length(area_m2)){
-        current = area_m2[k]
-        prior = area_m2[k-1]
-        area_add = current+prior
-        area_mult= current*prior
-        area_sqrt = sqrt(area_mult)
-        area_val[[k]] = area_add+area_sqrt
+    
+    if(length(up_ind[[1]])==0){
+      up_ind[[1]] = 2
     }
-    area_param = c(NA, unlist(area_val))
-    lakeObs$storage_dt = (ht_change*area_param)/3
-  
-    # Put data into table matching LakeFlow code (synthetic dataset): 
-    lakeObsOut = lakeObs
-    upObsOut = upObs
-    dnObsOut = dnObs
-    names(lakeObsOut) = c("date_l", "wse_l", "area_total_l", "month", "et", "tributary_total", "storage_l", "storage_dt_l")
-    names(upObsOut) = paste0(names(upObs), "_u")
-    names(dnObsOut) = paste0(names(dnObs), "_d")
-  
-    # Split dataframes by group into lists of dataframes.  
-    up_df_list = split(upObsOut, by='reach_id_u')
-    dn_df_list = split(dnObsOut, by='reach_id_d')
-  
-    # n days between observations. 
-    lakeObsOut$n_days = c(NA, as.numeric(diff(lakeObsOut$date_l)))
-  
-    # Remove first day from all dataframes bc dv is missing. 
-    lakeObsOut = lakeObsOut[-1,]
-    up_df_list = lapply(up_df_list, function(f) f[-1,])
-    dn_df_list = lapply(dn_df_list, function(f) f[-1,])
-  
-    # Transpose the data to get in proper format for stan. 
-    up_df_wide = lapply(up_df_list, t)
-    dn_df_wide = lapply(dn_df_list, t)
-  
-    # Combine the swot obs of multiple reaches back together.  
-    up_df_out = do.call('rbind', up_df_wide)
-    dn_df_out = do.call('rbind', dn_df_wide)
-  
-    # Create seperate matrices for each type of swot obs. Time across, reach down
-    up_df_stan = lapply(names(upObsOut)[-1], function(f) as.matrix(up_df_out[grep(f,rownames(up_df_out)),]))
-    names(up_df_stan) = names(upObsOut)[-1]
-    up_df_stan = lapply(up_df_stan, apply, 2, as.numeric)
-  
-    dn_df_stan = lapply(names(dnObsOut)[-1], function(f) as.matrix(dn_df_out[grep(f,rownames(dn_df_out)),]))
-    names(dn_df_stan) = names(dnObsOut)[-1]
-    dn_df_stan = lapply(dn_df_stan, apply, 2, as.numeric)
-  
-    transposer <- function(df) {
-        z<-t(df)
+    
+    up_qhat = lapply(unlist(up_ind), function(x){t(as.matrix(model_list[[x]]$value))})
+    up_qhat = do.call(rbind, up_qhat)
+    
+    dn_qhat = lapply(unlist(dn_ind), function(x){t(as.matrix(model_list[[x]]$value))})
+    dn_qhat = do.call(rbind, dn_qhat)
+    
+    up_sos_stan$qHat_u = up_qhat
+    dn_sos_stan$qHat_d = dn_qhat
+    
+  }else{
+    #sword_geoglows = fread(paste0(inPath, '/ancillary/sword_geoglows.csv'))
+    sword_reaches = c(upID, dnID)
+    #sword_geoglows$reach_id = as.character(sword_geoglows$reach_id)
+    sword_geoglows_filt = sword_geoglows[sword_geoglows$reach_id%in%sword_reaches,c('reach_id','LINKNO')]
+    geoglows_reaches = unique(as.list(sword_geoglows$LINKNO[sword_geoglows$reach_id%in%sword_reaches]))
+    # Pull in modeled geoglows data. 
+    #model_data = pull_geoglows(geoglows_reaches, '01-01-1940')
+    model_data <- fread(file.path(indir,paste0("clean/geoglows_", lake, ".csv")))
+    model_data$Date <- as.Date(model_data$Date)
+    # Convert bad Q to NA. 
+    ind = ncol(model_data)-1
+    model_data[,1:ind][model_data[,1:ind] < 0] <- 0.1
+    # When model data is unavailable (NRT SWOT data), use mean model. 
+    missing_dates = data.table(Date=seq.Date((max(model_data$Date)+1), Sys.Date(), by=1))
+    model_data = bind_rows(model_data, missing_dates)
+    model_data[] <- lapply(model_data, function(x) { 
+      x[is.na(x)] <- mean(x, na.rm = TRUE)
+      x})
+    #model_data = model_data[model_data$Date%in%lakeObsOut$date_l,]
+    model_annual = model_data[,year:=lubridate::year(Date),]
+    model_wide = melt(model_data, id.vars=c('year'))
+    model_wide = model_wide[,list(value=mean(value)),by=list(year, variable)][,list(value=mean(value)),by=variable][variable!='Date']
+    model_wide = model_wide[rep(model_wide[,.I], nrow(lakeObsOut))]
+    
+    model_wide$LINKNO = as.character(model_wide$variable)
+    model_wide$reach_id = sword_geoglows_filt$reach_id[match(model_wide$LINKNO, sword_geoglows_filt$LINKNO)]
+    model_list = split(model_wide, by='reach_id')
+    
+    up_ind = lapply(up_sos_stan$reach_id_u,function(x){which(as.character(x)==names(model_list))})
+    dn_ind = lapply(dn_sos_stan$reach_id_d,function(x){which(as.character(x)==names(model_list))})
+    
+    if(length(unique(model_wide$LINKNO))==1){
+      up_ind[[1]] = 1
+      dn_ind[[1]] = 1
     }
-  
-    # If reach is only one value, transpose the data to match multiple inflow/outflow setups. 
-    if(length(upID)==1){
-        up_df_stan = lapply(up_df_stan, transposer)
-    }
-  
-    if(length(dnID)==1){
-        dn_df_stan = lapply(dn_df_stan, transposer)
-    }
-  
-    # dA shift function. 
-    da_shift_fun = function(x) median(x) - min(x)
-  
-    # dA scale to be greater than 0.
-    da_scale = function(x) x - min(x)
-  
-    # Apply the above functions. 
-    up_da_shift = array(apply(up_df_stan$d_x_area_u,1, da_shift_fun))
-    d_x_area_scaled_u = t(as.matrix(apply(up_df_stan$d_x_area_u, 1, da_scale)))
-  
-    dn_da_shift = array(apply(dn_df_stan$d_x_area_d,1, da_shift_fun))
-    d_x_area_scaled_d = t(as.matrix(apply(dn_df_stan$d_x_area_d, 1, da_scale)))
-  
-    # Function to extract priors from SOS. 
-    sos_pull = function(reach_id){
-        #sos = "sos/constrained/na_sword_v15_SOS_priors.nc"
-        #sos_outflow = RNetCDF::open.nc(sos)
-        #sos = "in/sos/constrained/na_sword_v15_SOS_priors.nc"
-        if (updated_pld$continent[updated_pld$lake_id==lake] == 1) {
-          sos = file.path(sos_dir, "af_sword_v16_SOS_priors.nc")
-        } else if (updated_pld$continent[updated_pld$lake_id==lake] == 2) {
-          sos = file.path(sos_dir, "eu_sword_v16_SOS_priors.nc")
-        } else if (updated_pld$continent[updated_pld$lake_id==lake] == 3) {
-          sos = file.path(sos_dir, "as_sword_v16_SOS_priors.nc")
-        } else if (updated_pld$continent[updated_pld$lake_id==lake] == 4) {
-          sos = file.path(sos_dir, "as_sword_v16_SOS_priors.nc")
-        } else if (updated_pld$continent[updated_pld$lake_id==lake] == 5) {
-          sos = file.path(sos_dir, "oc_sword_v16_SOS_priors.nc")
-        } else if (updated_pld$continent[updated_pld$lake_id==lake] == 6) {
-          sos = file.path(sos_dir, "sa_sword_v16_SOS_priors.nc")
-        } else {sos = file.path(sos_dir, "na_sword_v16_SOS_priors.nc")} #Sets NA priors for continents 7, 8, and 9
-        sos_outflow = RNetCDF::open.nc(sos)
-        reach_grp <- RNetCDF::grp.inq.nc(sos_outflow, "reaches")$self
-        reach_ids <- RNetCDF::var.get.nc(reach_grp, "reach_id")
-        index <- which(reach_ids==reach_id, arr.ind=TRUE)
-        gbp_grp <- RNetCDF::grp.inq.nc(sos_outflow, "gbpriors/reach")$self
-        geoA = RNetCDF::var.get.nc(gbp_grp, "logA0_hat")[index]
-        geoN = RNetCDF::var.get.nc(gbp_grp, "logn_hat")[index]
-        geoNlower = RNetCDF::var.get.nc(gbp_grp, "lowerbound_logn")[index]
-        geoNupper = RNetCDF::var.get.nc(gbp_grp, "upperbound_logn")[index]
-        geoAlower = RNetCDF::var.get.nc(gbp_grp, "lowerbound_A0")[index]
-        geoAupper = RNetCDF::var.get.nc(gbp_grp, "upperbound_A0")[index]
-        geoAsd = RNetCDF::var.get.nc(gbp_grp, "logA0_sd")[index]
-        geoNsd = RNetCDF::var.get.nc(gbp_grp, "logn_sd")[index]
-        model_grp <- RNetCDF::grp.inq.nc(sos_outflow, "model")$self
-        qHat <- RNetCDF::var.get.nc(model_grp, "mean_q")[index]
-        #Assign a prior of 1000 cms is q prior is NA. - probably makes sense to use some relationship between width and meanQ in the future.   
-        qHat = ifelse(is.na(qHat), 1000, qHat)
-        qUpper <- RNetCDF::var.get.nc(model_grp, "max_q")[index]
-        qLower <- RNetCDF::var.get.nc(model_grp, "min_q")[index]
-        qLower = ifelse(qLower<=0|is.na(qLower), 0.001, qLower)
-        qUpper = ifelse(is.na(qUpper),500000, qUpper)
-        sigma = RNetCDF::var.get.nc(gbp_grp, "sigma_man")[index]
-        qSd=RNetCDF::var.get.nc(gbp_grp, "logQ_sd")[index]
-        return(data.table(reach_id, geoA, geoN, geoNlower, geoNupper, geoAlower, geoAupper,
-                        geoAsd, geoNsd, qHat, qUpper, qLower, sigma, qSd))
-    }
-
-    # Create our own geobam priors when SoS provides null priors - common issue bc lake influenced reaches often don't pass SoS QAQC.
-    sos_fit = function(df){
-        reach_id = unique(unlist(df[grep('reach_id', names(df))]))#[[1]]
-        width_matrix = df[grep('width', names(df))][[1]]
-        slope_matrix = df[grep('slope2', names(df))][[1]]
-        geoA = estimate_logA0(width_matrix)
-        geoN = estimate_logn(slope_matrix, width_matrix)
-        geoNlower = estimate_lowerboundlogn(width_matrix)
-        geoNupper = estimate_upperboundlogn(width_matrix)
-        geoAlower = estimate_lowerboundA0(width_matrix)
-        geoAupper = estimate_upperboundA0(width_matrix)
-        geoAsd = estimate_A0SD(width_matrix)
-        geoNsd = estimate_lognSD(width_matrix)
-        #Talk to Craig about more informed estimates of the below. 
-        qHat = rep(NA, length(reach_id))
-        qLower = rep(NA, length(reach_id))
-        qUpper = rep(NA, length(reach_id))
-        qSd = rep(100, length(reach_id))
-        sigma = rep(0.25, length(reach_id))
-        #Assign a prior of 1000 cms is q prior is NA. - probably makes sense to use some relationship between width and meanQ in the future.   
-        qHat = ifelse(is.na(qHat), 1000, qHat)
-        qLower = ifelse(qLower<=0|is.na(qLower), 0.001, qLower)
-        qUpper = ifelse(is.na(qUpper),500000, qUpper)
-        return(list(data.table(reach_id, geoA, geoN, geoNlower, geoNupper, geoAlower, geoAupper,
-                      geoAsd, geoNsd, qHat, qUpper, qLower, sigma, qSd)))
-    }
-  
-    # Add u and d labels to each column of sos outputs - helps with organizing the data. 
-    nms_paste = function(df, added_label){
-        nms = colnames(df)
-        new_nms = paste0(nms, '_', added_label)
-        colnames(df) = new_nms
-        return(df)
-    }
-  
-    # Pull priors from sos 
-    #New 'any(is.na)...' is new to account for NA values in addition to zeros. 
-    up_sos = lapply(upID, sos_pull)
-    sos_geobam = 'sos'
-    if(any(unlist(lapply(up_sos, nrow))==0)|any(is.na(unlist(up_sos)))){
-        up_sos = sos_fit(up_df_stan)
-        sos_geobam = 'geobam'
-    }
-    up_sos = lapply(up_sos, nms_paste, 'u')
-  
-    dn_sos = lapply(dnID, sos_pull)
-    if(any(unlist(lapply(dn_sos, nrow))==0)|any(is.na(unlist(dn_sos)))){
-        dn_sos = sos_fit(dn_df_stan)
-        sos_geobam = 'geobam'
-    }
-    dn_sos = lapply(dn_sos, nms_paste, 'd')
-  
-    # Transpose the sos data to get in proper format for stan. 
-    up_sos_wide = lapply(up_sos, t)
-    dn_sos_wide = lapply(dn_sos, t)
-  
-    # Combine the sos priors of multiple reaches together.  
-    up_sos_out = do.call('rbind', up_sos_wide)
-    dn_sos_out = do.call('rbind', dn_sos_wide)
-  
-    # Create seperate matrices for each type of sos prior. reach down time across. 
-    up_sos_stan = lapply(colnames(up_sos[[1]]), function(f) as.matrix(up_sos_out[grep(f,rownames(up_sos_out)),]))
-    names(up_sos_stan) = colnames(up_sos[[1]])
-    up_sos_stan = lapply(up_sos_stan, apply, 2, as.numeric)
-  
-    dn_sos_stan = lapply(colnames(dn_sos[[1]]), function(f) as.matrix(dn_sos_out[grep(f,rownames(dn_sos_out)),]))
-    names(dn_sos_stan) = colnames(dn_sos[[1]])
-    dn_sos_stan = lapply(dn_sos_stan, apply, 2, as.numeric)
-  
-    # Place in array to meet stan needs. 
-    up_sos_stan = lapply(up_sos_stan, array)
-    dn_sos_stan = lapply(dn_sos_stan, array)
-  
-    # Create matrix for select priors that need to be length of obs for stan. 
-    convert_to_matrix = function(f){
-        n = length(f)
-        output = apply(f, 1, rep, nrow(lakeObsOut))
-        return(t(output))
-    }
-  
-    up_sos_stan$sigma_u=convert_to_matrix(up_sos_stan$sigma_u)
-    dn_sos_stan$sigma_d=convert_to_matrix(dn_sos_stan$sigma_d)
-    up_sos_stan$qSd_u = convert_to_matrix(up_sos_stan$qSd_u)
-    dn_sos_stan$qSd_d = convert_to_matrix(dn_sos_stan$qSd_d)
-    up_sos_stan$qHat_u = convert_to_matrix(up_sos_stan$qHat_u)
-    dn_sos_stan$qHat_d = convert_to_matrix(dn_sos_stan$qHat_d)
-  
-    if(length(up_sos_stan$reach_id_u)==0){return(NA)}
-    if(length(dn_sos_stan$reach_id_d)==0){return(NA)}
-  
-  
-    # Pull in Modeled timeseries as prior Q rather than mean: #Updating alternative to using static Geoglows mean annual flow. 
-    if(use_ts_prior==TRUE){
-        #sword_geoglows = fread(paste0(inPath, '/ancillary/sword_geoglows.csv'))
-        sword_reaches = c(upID, dnID)
-        #sword_geoglows$reach_id = as.character(sword_geoglows$reach_id)
-        sword_geoglows_filt = sword_geoglows[sword_geoglows$reach_id%in%sword_reaches,c('reach_id','LINKNO')]
-        geoglows_reaches = unique(as.list(sword_geoglows$LINKNO[sword_geoglows$reach_id%in%sword_reaches]))
-        # Pull in modeled geoglows data. 
-        #model_data = pull_geoglows(geoglows_reaches, '01-01-1940')
-        model_data <- fread(file.path(indir,paste0("clean/geoglows_", lake, ".csv")))
-        model_data$Date <- as.Date(model_data$Date)
-        # Convert bad Q to NA. 
-        ind = ncol(model_data)-1
-        model_data[,1:ind][model_data[,1:ind] < 0] <- 0.1
-        # When model data is unavailable (NRT SWOT data), use mean model. 
-        missing_dates = data.table(Date=seq.Date((max(model_data$Date)+1), Sys.Date(), by=1))
-        model_data = bind_rows(model_data, missing_dates)
-        model_data[] <- lapply(model_data, function(x) { 
-            x[is.na(x)] <- mean(x, na.rm = TRUE)
-            x})
-        model_data_all = model_data
-        model_data = model_data[model_data$Date%in%lakeObsOut$date_l,]
-        model_wide = melt(model_data, id.vars=c('Date'))
-        model_wide$LINKNO = as.character(model_wide$variable)
-        model_wide$reach_id = sword_geoglows_filt$reach_id[match(model_wide$LINKNO, sword_geoglows_filt$LINKNO)]
-        model_list = split(model_wide, by='reach_id')
     
-        up_ind = lapply(up_sos_stan$reach_id_u,function(x){which(as.character(x)==names(model_list))})
-        dn_ind = lapply(dn_sos_stan$reach_id_d,function(x){which(as.character(x)==names(model_list))})
+    up_qhat = lapply(unlist(up_ind), function(x){t(as.matrix(model_list[[x]]$value))})
+    up_qhat = do.call(rbind, up_qhat)
     
-        if(length(unique(model_wide$LINKNO))==1){
-            up_ind[[1]] = 1
-            dn_ind[[1]] = 1
-            }
+    dn_qhat = lapply(unlist(dn_ind), function(x){t(as.matrix(model_list[[x]]$value))})
+    dn_qhat = do.call(rbind, dn_qhat)
     
-        if(length(up_ind[[1]])==0){
-            up_ind[[1]] = 2
-            }
-    
-        up_qhat = lapply(unlist(up_ind), function(x){t(as.matrix(model_list[[x]]$value))})
-        up_qhat = do.call(rbind, up_qhat)
-    
-        dn_qhat = lapply(unlist(dn_ind), function(x){t(as.matrix(model_list[[x]]$value))})
-        dn_qhat = do.call(rbind, dn_qhat)
-    
-        up_sos_stan$qHat_u = up_qhat
-        dn_sos_stan$qHat_d = dn_qhat
-    
-    }else{
-        #sword_geoglows = fread(paste0(inPath, '/ancillary/sword_geoglows.csv'))
-        sword_reaches = c(upID, dnID)
-        #sword_geoglows$reach_id = as.character(sword_geoglows$reach_id)
-        sword_geoglows_filt = sword_geoglows[sword_geoglows$reach_id%in%sword_reaches,c('reach_id','LINKNO')]
-        geoglows_reaches = unique(as.list(sword_geoglows$LINKNO[sword_geoglows$reach_id%in%sword_reaches]))
-        # Pull in modeled geoglows data. 
-        #model_data = pull_geoglows(geoglows_reaches, '01-01-1940')
-        model_data <- fread(file.path(indir,paste0("clean/geoglows_", lake, ".csv")))
-        model_data$Date <- as.Date(model_data$Date)
-        # Convert bad Q to NA. 
-        ind = ncol(model_data)-1
-        model_data[,1:ind][model_data[,1:ind] < 0] <- 0.1
-        # When model data is unavailable (NRT SWOT data), use mean model. 
-        missing_dates = data.table(Date=seq.Date((max(model_data$Date)+1), Sys.Date(), by=1))
-        model_data = bind_rows(model_data, missing_dates)
-        model_data[] <- lapply(model_data, function(x) { 
-            x[is.na(x)] <- mean(x, na.rm = TRUE)
-            x})
-        #model_data = model_data[model_data$Date%in%lakeObsOut$date_l,]
-        model_annual = model_data[,year:=lubridate::year(Date),]
-        model_wide = melt(model_data, id.vars=c('year'))
-        model_wide = model_wide[,list(value=mean(value)),by=list(year, variable)][,list(value=mean(value)),by=variable][variable!='Date']
-        model_wide = model_wide[rep(model_wide[,.I], nrow(lakeObsOut))]
-    
-        model_wide$LINKNO = as.character(model_wide$variable)
-        model_wide$reach_id = sword_geoglows_filt$reach_id[match(model_wide$LINKNO, sword_geoglows_filt$LINKNO)]
-        model_list = split(model_wide, by='reach_id')
-    
-        up_ind = lapply(up_sos_stan$reach_id_u,function(x){which(as.character(x)==names(model_list))})
-        dn_ind = lapply(dn_sos_stan$reach_id_d,function(x){which(as.character(x)==names(model_list))})
-    
-        if(length(unique(model_wide$LINKNO))==1){
-            up_ind[[1]] = 1
-            dn_ind[[1]] = 1
-        }
-    
-        up_qhat = lapply(unlist(up_ind), function(x){t(as.matrix(model_list[[x]]$value))})
-        up_qhat = do.call(rbind, up_qhat)
-    
-        dn_qhat = lapply(unlist(dn_ind), function(x){t(as.matrix(model_list[[x]]$value))})
-        dn_qhat = do.call(rbind, dn_qhat)
-    
-        up_sos_stan$qHat_u = up_qhat
-        dn_sos_stan$qHat_d = dn_qhat
-    }
+    up_sos_stan$qHat_u = up_qhat
+    dn_sos_stan$qHat_d = dn_qhat
+  }
   
-    #New: Stan can't handle 0 prior estimates of discharge. So it replaces it with the mean value. 
-    up_sos_stan$qHat_u = ifelse(up_sos_stan$qHat_u<=0, mean(up_sos_stan$qHat_u), up_sos_stan$qHat_u)
-    dn_sos_stan$qHat_d = ifelse(dn_sos_stan$qHat_d<=0, mean(dn_sos_stan$qHat_d), dn_sos_stan$qHat_d)
+  #New: Stan can't handle 0 prior estimates of discharge. So it replaces it with the mean value. 
+  up_sos_stan$qHat_u = ifelse(up_sos_stan$qHat_u<=0, mean(up_sos_stan$qHat_u), up_sos_stan$qHat_u)
+  dn_sos_stan$qHat_d = ifelse(dn_sos_stan$qHat_d<=0, mean(dn_sos_stan$qHat_d), dn_sos_stan$qHat_d)
   
-    # Combine all data needed for stan. 
-    stan_data = list(N = nrow(lakeObsOut),
-                    n1=length(upID),
-                    n2=length(dnID),
-                    sigmaIn = up_sos_stan$sigma_u,
-                    sigmaOut = dn_sos_stan$sigma_d,
-                    qInSd = up_sos_stan$qSd_u,#rep(qInSd,nrow(data)),#qInSd used to multiply by 0.1?
-                    qOutSd = dn_sos_stan$qSd_d,#rep(qOutSd,nrow(data)),#qOutSd used to multiply by 0.1?
-                    q = log(up_sos_stan$qHat_u),#rep(log(qHatIn),nrow(data)),
-                    sigma = up_sos_stan$sigma_u,#rep(0.25, nrow(data)),
-                    da = d_x_area_scaled_u,#data$upArea_dt_u-min(data$upArea_dt_u, na.rm=T), # possible error from Ryan: dA is already change in A, but he's subtracting min dA 
-                    w=log(up_df_stan$width_u),
-                    s=log(up_df_stan$slope2_u), # using smoothed slope (slope2) to minimize negatives
-                    da2=d_x_area_scaled_d,#da2=data$dnArea_dt_d-min(data$dnArea_dt_d, na.rm=T), # possible error from Ryan: dA is already change in A, but he's subtracting min dA 
-                    w2=log(dn_df_stan$width_d),
-                    s2=log(dn_df_stan$slope2_d), # = smoothed slope (slope2) produced similar results as raw slope 
-                    q2=log(dn_sos_stan$qHat_d),#rep(log(qHatOut),nrow(data)),
-                    #dv=data$storage_dt_l/86400, #seconds per day
-                    et=lakeObsOut$et,#rep(0, nrow(lakeObsOut)), # filled with zero vals right now
-                    lateral=lakeObsOut$tributary_total,#rep(0,nrow(lakeObsOut)), # filled with zero vals right now
-                    dv_per = (lakeObsOut$storage_dt_l/86400)/lakeObsOut$n_days)
+  # Combine all data needed for stan. 
+  stan_data = list(N = nrow(lakeObsOut),
+                   n1=length(upID),
+                   n2=length(dnID),
+                   sigmaIn = up_sos_stan$sigma_u,
+                   sigmaOut = dn_sos_stan$sigma_d,
+                   qInSd = up_sos_stan$qSd_u,#rep(qInSd,nrow(data)),#qInSd used to multiply by 0.1?
+                   qOutSd = dn_sos_stan$qSd_d,#rep(qOutSd,nrow(data)),#qOutSd used to multiply by 0.1?
+                   q = log(up_sos_stan$qHat_u),#rep(log(qHatIn),nrow(data)),
+                   sigma = up_sos_stan$sigma_u,#rep(0.25, nrow(data)),
+                   da = d_x_area_scaled_u,#data$upArea_dt_u-min(data$upArea_dt_u, na.rm=T), # possible error from Ryan: dA is already change in A, but he's subtracting min dA 
+                   w=log(up_df_stan$width_u),
+                   s=log(up_df_stan$slope2_u), # using smoothed slope (slope2) to minimize negatives
+                   da2=d_x_area_scaled_d,#da2=data$dnArea_dt_d-min(data$dnArea_dt_d, na.rm=T), # possible error from Ryan: dA is already change in A, but he's subtracting min dA 
+                   w2=log(dn_df_stan$width_d),
+                   s2=log(dn_df_stan$slope2_d), # = smoothed slope (slope2) produced similar results as raw slope 
+                   q2=log(dn_sos_stan$qHat_d),#rep(log(qHatOut),nrow(data)),
+                   #dv=data$storage_dt_l/86400, #seconds per day
+                   et=lakeObsOut$et,#rep(0, nrow(lakeObsOut)), # filled with zero vals right now
+                   lateral=lakeObsOut$tributary_total,#rep(0,nrow(lakeObsOut)), # filled with zero vals right now
+                   dv_per = (lakeObsOut$storage_dt_l/86400)/lakeObsOut$n_days)
   
   
-    # set NAs, NaNs, and Inf to 0 for stan (Ryan's code):
-    stan_data$da = ifelse(is.na(stan_data$da)|is.infinite(stan_data$da), 0, stan_data$da)
-    stan_data$da2 = ifelse(is.na(stan_data$da2)|is.infinite(stan_data$da2), 0, stan_data$da2)
-    stan_data$s = ifelse(is.na(stan_data$s), 0, stan_data$s)
-    stan_data$s2 = ifelse(is.na(stan_data$s2), 0, stan_data$s2)
-    stan_data$lateral = ifelse(is.na(stan_data$lateral), 0, stan_data$lateral)
-    stan_data$et = ifelse(is.na(stan_data$et), 0, stan_data$et)
-    stan_data$nInlower = up_sos_stan$geoNlower_u #as.array(geoNInlower)
-    stan_data$nInupper = up_sos_stan$geoNupper_u#as.array(geoNInupper)
-    stan_data$aInlower= up_sos_stan$geoAlower_u#as.array(geoAInlower)
-    stan_data$aInupper = up_sos_stan$geoAupper_u#as.array(geoAInupper)
-    stan_data$nOutlower = dn_sos_stan$geoNlower_d#as.array(geoNOutlower)
-    stan_data$nOutupper = dn_sos_stan$geoNupper_d#as.array(geoNOutupper)
-    stan_data$aOutlower= dn_sos_stan$geoAlower_d#as.array(geoAOutlower)
-    stan_data$aOutupper = dn_sos_stan$geoAupper_d#as.array(geoAOutupper)
-    stan_data$daInShift = up_da_shift#apply(up_df_stan$d_x_area_u,1, da_shift_fun)#as.array(da_shift_fun(data$upArea_dt_u))
-    stan_data$daOutShift = dn_da_shift#apply(dn_df_stan$d_x_area_d,1, da_shift_fun)#as.array(da_shift_fun(data$dnArea_dt_d))
-    stan_data$nInHat = up_sos_stan$geoN_u#as.array(geoNin)
-    stan_data$nInSd = up_sos_stan$geoNsd_u#as.array(0.25) # Ryan, what's this? 
-    stan_data$aInHat = up_sos_stan$geoA_u#as.array(geoAin)
-    stan_data$aInSd = up_sos_stan$geoAsd_u#as.array(geoAinSD)
-    stan_data$qInupper=log(up_sos_stan$qUpper_u)#as.array(log(qInupper))
-    stan_data$qInlower=log(up_sos_stan$qLower_u)#as.array(log(qInlower))
-    stan_data$nOutHat = dn_sos_stan$geoN_d#as.array(geoNout) 
-    stan_data$nOutSd = dn_sos_stan$geoNsd_d#as.array(0.25)
-    stan_data$aOutHat = dn_sos_stan$geoA_d#as.array(geoAout)
-    stan_data$aOutSd = dn_sos_stan$geoAsd_d#as.array(geoAoutSD)
-    stan_data$qOutupper=log(dn_sos_stan$qUpper_d)#as.array(log(qOutupper))
-    stan_data$qOutlower=log(dn_sos_stan$qLower_d)#as.array(log(qOutlower))
+  # set NAs, NaNs, and Inf to 0 for stan (Ryan's code):
+  stan_data$da = ifelse(is.na(stan_data$da)|is.infinite(stan_data$da), 0, stan_data$da)
+  stan_data$da2 = ifelse(is.na(stan_data$da2)|is.infinite(stan_data$da2), 0, stan_data$da2)
+  stan_data$s = ifelse(is.na(stan_data$s), 0, stan_data$s)
+  stan_data$s2 = ifelse(is.na(stan_data$s2), 0, stan_data$s2)
+  stan_data$lateral = ifelse(is.na(stan_data$lateral), 0, stan_data$lateral)
+  stan_data$et = ifelse(is.na(stan_data$et), 0, stan_data$et)
+  stan_data$nInlower = up_sos_stan$geoNlower_u #as.array(geoNInlower)
+  stan_data$nInupper = up_sos_stan$geoNupper_u#as.array(geoNInupper)
+  stan_data$aInlower= up_sos_stan$geoAlower_u#as.array(geoAInlower)
+  stan_data$aInupper = up_sos_stan$geoAupper_u#as.array(geoAInupper)
+  stan_data$nOutlower = dn_sos_stan$geoNlower_d#as.array(geoNOutlower)
+  stan_data$nOutupper = dn_sos_stan$geoNupper_d#as.array(geoNOutupper)
+  stan_data$aOutlower= dn_sos_stan$geoAlower_d#as.array(geoAOutlower)
+  stan_data$aOutupper = dn_sos_stan$geoAupper_d#as.array(geoAOutupper)
+  stan_data$daInShift = up_da_shift#apply(up_df_stan$d_x_area_u,1, da_shift_fun)#as.array(da_shift_fun(data$upArea_dt_u))
+  stan_data$daOutShift = dn_da_shift#apply(dn_df_stan$d_x_area_d,1, da_shift_fun)#as.array(da_shift_fun(data$dnArea_dt_d))
+  stan_data$nInHat = up_sos_stan$geoN_u#as.array(geoNin)
+  stan_data$nInSd = up_sos_stan$geoNsd_u#as.array(0.25) # Ryan, what's this? 
+  stan_data$aInHat = up_sos_stan$geoA_u#as.array(geoAin)
+  stan_data$aInSd = up_sos_stan$geoAsd_u#as.array(geoAinSD)
+  stan_data$qInupper=log(up_sos_stan$qUpper_u)#as.array(log(qInupper))
+  stan_data$qInlower=log(up_sos_stan$qLower_u)#as.array(log(qInlower))
+  stan_data$nOutHat = dn_sos_stan$geoN_d#as.array(geoNout) 
+  stan_data$nOutSd = dn_sos_stan$geoNsd_d#as.array(0.25)
+  stan_data$aOutHat = dn_sos_stan$geoA_d#as.array(geoAout)
+  stan_data$aOutSd = dn_sos_stan$geoAsd_d#as.array(geoAoutSD)
+  stan_data$qOutupper=log(dn_sos_stan$qUpper_d)#as.array(log(qOutupper))
+  stan_data$qOutlower=log(dn_sos_stan$qLower_d)#as.array(log(qOutlower))
   
-    # Apply stan code. 
-    fit = try(stan("src/lakeflow_stan_flexible.stan",
-                    data=stan_data,
-                    chains=6,#4, #3
-                    cores=cores, #6
-                    iter=4000,#4000, #iter=4000
-                    control=list(stepsize=0.5,
-                                adapt_delta=0.9)))
-    if(is.error(fit)){next}
+  # Apply stan code. 
+  fit = try(stan("src/lakeflow_stan_flexible.stan",
+                 data=stan_data,
+                 chains=6,#4, #3
+                 cores=cores, #6
+                 iter=4000,#4000, #iter=4000
+                 control=list(stepsize=0.5,
+                              adapt_delta=0.9)))
+  if(is.error(fit)){next}
   
-    # Manning's eqn:
-    eqn1 = function(n, a, da, w, s){
-        flow = (n^-1)*((a+da)^(5/3))*(w^(-2/3))*(s^0.5)
-        return(flow)
-    }
+  # Manning's eqn:
+  eqn1 = function(n, a, da, w, s){
+    flow = (n^-1)*((a+da)^(5/3))*(w^(-2/3))*(s^0.5)
+    return(flow)
+  }
   
-    # Pull outputs from stan. 
-    mn = get_posterior_mean(fit)
-    rw = row.names(mn)
-    mn = data.table(mn)
-    mn$type = rw
-    if(nrow(mn)==0|ncol(mn)<6){return(NA)}
-    mn = mn[, c('type','mean-all chains')]
+  # Pull outputs from stan. 
+  mn = get_posterior_mean(fit)
+  rw = row.names(mn)
+  mn = data.table(mn)
+  mn$type = rw
+  if(nrow(mn)==0|ncol(mn)<6){return(NA)}
+  mn = mn[, c('type','mean-all chains')]
   
-    uncertainty = data.table(summary(fit)$summary)
-    uncertainty$type = mn$type
+  uncertainty = data.table(summary(fit)$summary)
+  uncertainty$type = mn$type
   
-    # Manning's n estimates from stan
-    roughness_inflow = mn[startsWith(mn$type,'n[')]
-    roughness_inflow_sd = uncertainty[startsWith(uncertainty$type,'n[')]
-    roughness_outflow = mn[startsWith(mn$type,'nOut[')]
-    roughness_outflow_sd = uncertainty[startsWith(uncertainty$type,'nOut[')]
+  # Manning's n estimates from stan
+  roughness_inflow = mn[startsWith(mn$type,'n[')]
+  roughness_inflow_sd = uncertainty[startsWith(uncertainty$type,'n[')]
+  roughness_outflow = mn[startsWith(mn$type,'nOut[')]
+  roughness_outflow_sd = uncertainty[startsWith(uncertainty$type,'nOut[')]
   
-    # A0 estimates from stan
-    bath_inflow = mn[startsWith(mn$type,'a[')]
-    bath_inflow_sd = uncertainty[startsWith(uncertainty$type,'a[')]
-    bath_outflow = mn[startsWith(mn$type,'aOut[')]
-    bath_outflow_sd = uncertainty[startsWith(uncertainty$type,'aOut[')]
+  # A0 estimates from stan
+  bath_inflow = mn[startsWith(mn$type,'a[')]
+  bath_inflow_sd = uncertainty[startsWith(uncertainty$type,'a[')]
+  bath_outflow = mn[startsWith(mn$type,'aOut[')]
+  bath_outflow_sd = uncertainty[startsWith(uncertainty$type,'aOut[')]
   
-    # Bayesian estimate of inflow and outflow - not used for our purposes. 
-    bayes_inflow = mn[startsWith(mn$type,'logQ_in[')]
-    bayes_inflow_sd = uncertainty[startsWith(uncertainty$type,'logQ_in[')]$sd
-    bayes_outflow = mn[startsWith(mn$type,'logQ_out[')]
-    bayes_outflow_sd = uncertainty[startsWith(uncertainty$type,'logQ_out[')]$sd
+  # Bayesian estimate of inflow and outflow - not used for our purposes. 
+  bayes_inflow = mn[startsWith(mn$type,'logQ_in[')]
+  bayes_inflow_sd = uncertainty[startsWith(uncertainty$type,'logQ_in[')]$sd
+  bayes_outflow = mn[startsWith(mn$type,'logQ_out[')]
+  bayes_outflow_sd = uncertainty[startsWith(uncertainty$type,'logQ_out[')]$sd
   
-    # Quick way to organize the data in case of varying N of inflows/outflows - could be placed in a function at some point. 
-    inflow_outputs = list()
-    for(j in 1:length(upID)){
-        q_estimate = eqn1(exp(roughness_inflow$`mean-all chains`[j]),bath_inflow$`mean-all chains`[j],
+  # Quick way to organize the data in case of varying N of inflows/outflows - could be placed in a function at some point. 
+  inflow_outputs = list()
+  for(j in 1:length(upID)){
+    q_estimate = eqn1(exp(roughness_inflow$`mean-all chains`[j]),bath_inflow$`mean-all chains`[j],
                       d_x_area_scaled_u[j,],up_df_stan$width_u[j,], up_df_stan$slope2_u[j,])
-        q_bayes = bayes_inflow$`mean-all chains`[bayes_inflow$type]
-        inflow_outputs[[j]] = data.table(q_lakeflow = q_estimate, reach_id=upID[j], n_lakeflow=exp(roughness_inflow$`mean-all chains`[j]),a0_lakeflow=bath_inflow$`mean-all chains`[j],date=lakeObsOut$date_l,lake_id=lake,q_model=up_sos_stan$qHat_u[j,],
+    q_bayes = bayes_inflow$`mean-all chains`[bayes_inflow$type]
+    inflow_outputs[[j]] = data.table(q_lakeflow = q_estimate, reach_id=upID[j], n_lakeflow=exp(roughness_inflow$`mean-all chains`[j]),a0_lakeflow=bath_inflow$`mean-all chains`[j],date=lakeObsOut$date_l,lake_id=lake,q_model=up_sos_stan$qHat_u[j,],
                                      width = stan_data$w[j,], slope2 = stan_data$s[j,], da = d_x_area_scaled_u[j,], wse = up_df_stan$wse_u[j,],
                                      storage=lakeObsOut$storage_l,dv=stan_data$dv_per, tributary=stan_data$lateral, et=stan_data$et,type='inflow',n_lakeflow_sd = roughness_inflow_sd$sd[j],a0_lakeflow_sd =bath_inflow_sd$sd[j],
                                      q_upper = stan_data$qInupper[j],q_lower = stan_data$qInlower[j])
-    }
-    inflow_outputs = rbindlist(inflow_outputs)
-    inflow_outputs$bayes_q = bayes_inflow$`mean-all chains`
-    inflow_outputs$bayes_q_sd = bayes_inflow_sd
+  }
+  inflow_outputs = rbindlist(inflow_outputs)
+  inflow_outputs$bayes_q = bayes_inflow$`mean-all chains`
+  inflow_outputs$bayes_q_sd = bayes_inflow_sd
   
-    outflow_outputs = list()
-    for(j in 1:length(dnID)){
-        q_estimate = eqn1(exp(roughness_outflow$`mean-all chains`[j]),bath_outflow$`mean-all chains`[j],
+  outflow_outputs = list()
+  for(j in 1:length(dnID)){
+    q_estimate = eqn1(exp(roughness_outflow$`mean-all chains`[j]),bath_outflow$`mean-all chains`[j],
                       d_x_area_scaled_d[j,],dn_df_stan$width_d[j,], dn_df_stan$slope2_d[j,])
-        outflow_outputs[[j]] = data.table(q_lakeflow = q_estimate, reach_id=dnID[j], n_lakeflow=exp(roughness_outflow$`mean-all chains`[j]),a0_lakeflow=bath_outflow$`mean-all chains`[j],date=lakeObsOut$date_l,lake_id=lake,q_model=dn_sos_stan$qHat_d[j,],
+    outflow_outputs[[j]] = data.table(q_lakeflow = q_estimate, reach_id=dnID[j], n_lakeflow=exp(roughness_outflow$`mean-all chains`[j]),a0_lakeflow=bath_outflow$`mean-all chains`[j],date=lakeObsOut$date_l,lake_id=lake,q_model=dn_sos_stan$qHat_d[j,],
                                       width = stan_data$w2[j,], slope2 = stan_data$s2[j,], da = d_x_area_scaled_d[j,], wse = dn_df_stan$wse_d[j,],
                                       storage=lakeObsOut$storage_l,dv=stan_data$dv_per, tributary=stan_data$lateral, et=stan_data$et,type='outflow',n_lakeflow_sd = roughness_outflow_sd$sd[j],a0_lakeflow_sd =bath_outflow_sd$sd[j],
                                       q_upper = stan_data$qOutupper[j],q_lower = stan_data$qOutlower[j])
-    }
-    outflow_outputs = rbindlist(outflow_outputs)
-    outflow_outputs$bayes_q = bayes_outflow$`mean-all chains`
-    outflow_outputs$bayes_q_sd = bayes_outflow_sd
+  }
+  outflow_outputs = rbindlist(outflow_outputs)
+  outflow_outputs$bayes_q = bayes_outflow$`mean-all chains`
+  outflow_outputs$bayes_q_sd = bayes_outflow_sd
   
   
   
-    output_df = bind_rows(inflow_outputs, outflow_outputs)
-    output_df$prior_fit = sos_geobam
-    fwrite(output_df, file.path(outdir, paste0(lake, '.csv')))
-
-    return()
-
-    }
+  output_df = bind_rows(inflow_outputs, outflow_outputs)
+  output_df$prior_fit = sos_geobam
+  fwrite(output_df, file.path(outdir, paste0(lake, '.csv')))
+  
+  return()
+  
+}
 
 
 ################################################################################
@@ -578,9 +578,9 @@ lakeFlow = function(lake){
 ################################################################################
 
 if (is.null(index)){
-    lake_data <- lakes  
+  lake_data <- lakes  
 }else{
-    lake_data <- lakes[index, , drop = FALSE]
+  lake_data <- lakes[index, , drop = FALSE]
 }
 
 for(i in 1:nrow(lake_data)){

--- a/src/lakeflow_2.R
+++ b/src/lakeflow_2.R
@@ -36,6 +36,7 @@ option_list <- list(
   make_option(c("-w", "--workers"), type = "integer", default = NULL, help = "number of cores for lakeflow to use"),
   make_option(c("-i", "--indir"), type = "character", default = NULL , help = "directory with input files"),
   make_option(c("-o", "--outdir"), type = "character", default = NULL , help = "directory to output results"),
+  make_option(c("-v", "--swordversion"), type = "character", default = "17", help = "version of sword we are using"),
   make_option(c("--index"), type = "integer", default = NULL, help = "index of what lake to process in the input file if blank process whole file")
 )
 ################################################################################
@@ -63,6 +64,9 @@ sos_dir <- opts$sos_dir
 
 # Path that you write to
 outdir <- opts$outdir
+
+# SWORD product version
+SWORD_VERSION <- opts$swordversion
 
 # Set index, use aws array if index is -256 (ascii code for AWS)
 index <- opts$index
@@ -207,18 +211,18 @@ lakeFlow = function(lake){
     #sos_outflow = RNetCDF::open.nc(sos)
     #sos = "in/sos/constrained/na_sword_v15_SOS_priors.nc"
     if (updated_pld$continent[updated_pld$lake_id==lake] == 1) {
-      sos = file.path(sos_dir, "af_sword_v17_SOS_priors.nc")
+      sos = file.path(sos_dir,paste0("af_sword_v", SWORD_VERSION, "_SOS_priors.nc"))
     } else if (updated_pld$continent[updated_pld$lake_id==lake] == 2) {
-      sos = file.path(sos_dir, "eu_sword_v17_SOS_priors.nc")
+      sos = file.path(sos_dir,paste0("eu_sword_v", SWORD_VERSION, "_SOS_priors.nc"))
     } else if (updated_pld$continent[updated_pld$lake_id==lake] == 3) {
-      sos = file.path(sos_dir, "as_sword_v17_SOS_priors.nc")
+      sos = file.path(sos_dir,paste0("as_sword_v", SWORD_VERSION, "_SOS_priors.nc"))
     } else if (updated_pld$continent[updated_pld$lake_id==lake] == 4) {
-      sos = file.path(sos_dir, "as_sword_v17_SOS_priors.nc")
+      sos = file.path(sos_dir,paste0("as_sword_v", SWORD_VERSION, "_SOS_priors.nc"))
     } else if (updated_pld$continent[updated_pld$lake_id==lake] == 5) {
-      sos = file.path(sos_dir, "oc_sword_v17_SOS_priors.nc")
+      sos = file.path(sos_dir,paste0("oc_sword_v", SWORD_VERSION, "_SOS_priors.nc"))
     } else if (updated_pld$continent[updated_pld$lake_id==lake] == 6) {
-      sos = file.path(sos_dir, "sa_sword_v17_SOS_priors.nc")
-    } else {sos = file.path(sos_dir, "na_sword_v17_SOS_priors.nc")} #Sets NA priors for continents 7, 8, and 9
+      sos = file.path(sos_dir,paste0("sa_sword_v", SWORD_VERSION, "_SOS_priors.nc"))
+    } else {sos = file.path(sos_dir,paste0("na_sword_v", SWORD_VERSION, "_SOS_priors.nc"))} #Sets NA priors for continents 7, 8, and 9
     sos_outflow = RNetCDF::open.nc(sos)
     reach_grp <- RNetCDF::grp.inq.nc(sos_outflow, "reaches")$self
     reach_ids <- RNetCDF::var.get.nc(reach_grp, "reach_id")

--- a/src/lakeflow_2.R
+++ b/src/lakeflow_2.R
@@ -84,7 +84,7 @@ updated_pld = fread(file.path(indir,"SWORDv17b_PLDv201.csv"))
 updated_pld$lake_id =  as.character(updated_pld$lake_id)
 updated_pld$continent = substr(updated_pld$lake_id, 1,1)
 
-sword_geoglows = fread(file.path(indir,'ancillary/sword_geoglows_w_ghost_reach.csv'))
+sword_geoglows = fread(file.path(indir,'ancillary/sword_geoglows.csv'))
 sword_geoglows$reach_id = as.character(sword_geoglows$reach_id)
 
 ################################################################################

--- a/src/lakeflow_2_submit.sh
+++ b/src/lakeflow_2_submit.sh
@@ -20,4 +20,4 @@ apptainer exec \
     --pwd /projects/swot/hana/LakeFlow_Confluence \
     --bind /projects/swot/hana/LakeFlow_Confluence \
     --cleanenv \
-    /projects/swot/hana/LakeFlow_Confluence/lakeflow_deploy.sif Rscript src/lakeflow_2.R -c "in/viable/lakeflow${SLURM_ARRAY_TASK_ID}.csv" -s in/sos/constrained/ -w 6 -i in/ -o out/lf_results_global_run_6_vD_et/
+    /projects/swot/hana/LakeFlow_Confluence/lakeflow_deploy.sif Rscript src/lakeflow_2.R -c "in/viable/lakeflow${SLURM_ARRAY_TASK_ID}.csv" -s in/sos/constrained/ -w 6 -i in/ -o out/lf_results_global_run_6_vD_et/ -v 17

--- a/src/lakeflow_2_submit.sh
+++ b/src/lakeflow_2_submit.sh
@@ -15,9 +15,9 @@
 ####### end of job customization
 # end of environment & variable setup
 
-module load containers/apptainer
+module load apptainer/1.4.0
 apptainer exec \
     --pwd /projects/swot/hana/LakeFlow_Confluence \
     --bind /projects/swot/hana/LakeFlow_Confluence \
     --cleanenv \
-    /projects/swot/hana/LakeFlow_Confluence/lakeflow.sif Rscript src/lakeflow_2.R "in/viable/lakeflow${SLURM_ARRAY_TASK_ID}.csv" 6
+    /projects/swot/hana/LakeFlow_Confluence/lakeflow_deploy.sif Rscript src/lakeflow_2.R -c "in/viable/lakeflow${SLURM_ARRAY_TASK_ID}.csv" -s in/sos/constrained/ -w 6 -i in/ -o out/lf_results_global_run_6_vD_et/


### PR DESCRIPTION
This branch includes all of LakeFlow's updates for the next run of Confluence, scheduled for spring 2026.

Major changes include: 1) Updating algorithm to run on SWOT vD/SWORD v17; 2) Implementing a modified version of "setfinder", which allows LakeFlow to pull data from up to five reaches up/downstream; 3) Updating data filtering; 4) Adding new arguments to specify file location and version of SWORD; 5) Incorporating daily evaporation estimates.

There are two new arguments for LakeFlow_1/Input:
"-s", "--sword_dir": Path to the SWORD .nc files within the mnt (here, /mnt/input/sword)
"-v", "--swordversion": Version of SWORD we used (here, -v 17)

And, one new argument for LakeFlow_2/Deploy:
"-v", "--swordversion": Version of SWORD we used (here, -v 17)

Action Needed: Could these new arguments be added to the AWS terraform step function for LakeFlow Input and LakeFlow Deploy? Thank you so much!