### PR TITLE
New update to geoglows_aws_pull.py

### DIFF
--- a/src/geoglows_aws_pull.py
+++ b/src/geoglows_aws_pull.py
@@ -15,6 +15,9 @@ def pull_tributary(reach_id, start_date):
     s3store = s3fs.S3Map(root=bucket_uri, s3=s3, check=False)
     ds = xarray.open_zarr(s3store)
     
+    # In case the last value of time coordinate is NaT, drop it
+    ds = ds.isel(time=slice(None, -1)) if pd.isna(ds.time.values[-1]) else ds
+    
     end_date = min(datetime.date.today(), pd.Timestamp(ds["time"].values[-1]).date())
     second_index = end_date - sim_begin
     


### PR DESCRIPTION
This update includes a small modification to the geoglows_aws_pull.py script to account for a case where the model data from GeoGlows ended on a NaT time. If this happens again, the final row of data will be removed.